### PR TITLE
Add spotlight blockquote component. Unset include variables

### DIFF
--- a/_includes/sc-blockquote.html
+++ b/_includes/sc-blockquote.html
@@ -1,0 +1,17 @@
+{% assign size_class = include.sizing | default: 'large' | prepend: 'sc--' %}
+
+{% if include.align and size_class != 'sc--large' %}
+  {% assign align_class = include.align | prepend: 'sc--float-' %}
+{% endif %}
+
+{%- if include.content -%}
+<blockquote class="spotlight-component sc-blockquote {{ size_class }} {{ align_class }}">
+  {{ include.content }}
+  {%- if include.cite -%}
+  <cite>{{ include.cite }}</cite>
+  {%- endif -%}
+</blockquote>
+{%- endif -%}
+
+{%- assign size_class = null -%}
+{%- assign align_class = null -%}

--- a/_includes/sc-blockquote.html
+++ b/_includes/sc-blockquote.html
@@ -1,3 +1,6 @@
+{%- assign size_class = null -%}
+{%- assign align_class = null -%}
+
 {% assign size_class = include.sizing | default: 'large' | prepend: 'sc--' %}
 
 {% if include.align and size_class != 'sc--large' %}
@@ -12,6 +15,3 @@
   {%- endif -%}
 </blockquote>
 {%- endif -%}
-
-{%- assign size_class = null -%}
-{%- assign align_class = null -%}

--- a/_includes/sc-document.html
+++ b/_includes/sc-document.html
@@ -1,3 +1,4 @@
+{%- assign align_class = null -%}
 {% assign align_class = include.align | default: 'left' | prepend: 'sc--float-' %}
 
 {%- if include.url and include.label -%}
@@ -7,5 +8,3 @@
   <div class="spotlight-component__caption">{{ include.caption }}</div>
 </div>
 {%- endif -%}
-
-{%- assign align_class = null -%}

--- a/_includes/sc-document.html
+++ b/_includes/sc-document.html
@@ -7,3 +7,5 @@
   <div class="spotlight-component__caption">{{ include.caption }}</div>
 </div>
 {%- endif -%}
+
+{%- assign align_class = null -%}

--- a/_includes/sc-reference.html
+++ b/_includes/sc-reference.html
@@ -1,3 +1,5 @@
+{%- assign align_class = null -%}
+
 {% assign align_class = include.align | default: 'left' | prepend: 'sc--float-' %}
 
 {%- if include.url and include.label -%}
@@ -9,5 +11,3 @@
   <p>{{ include.caption }}</p>
 </div>
 {%- endif -%}
-
-{%- assign align_class = null -%}

--- a/_includes/sc-reference.html
+++ b/_includes/sc-reference.html
@@ -1,5 +1,6 @@
-{% assign align_class = include.align | default: 'left' | prepend: 'sc--float-'
-%} {%- if include.url and include.label -%}
+{% assign align_class = include.align | default: 'left' | prepend: 'sc--float-' %}
+
+{%- if include.url and include.label -%}
 <div class="spotlight-component sc-reference sc--float-small {{ align_class }}">
   <a href="{{ include.url }}" class="spotlight-component__label sc-link">
     {{ include.label }}
@@ -8,3 +9,5 @@
   <p>{{ include.caption }}</p>
 </div>
 {%- endif -%}
+
+{%- assign align_class = null -%}

--- a/_includes/sc-statistic.html
+++ b/_includes/sc-statistic.html
@@ -1,3 +1,5 @@
+{%- assign align_class = null -%}
+
 {% assign align_class = include.align | default: 'left' | prepend: 'sc--float-' %}
 
 {%- if include.number -%}
@@ -7,5 +9,3 @@
   {%- if include.post -%}<div class="spotlight-component__caption-serif">{{ include.post }}</div>{%- endif -%}
 </div>
 {%- endif -%}
-
-{%- assign align_class = null -%}

--- a/_includes/sc-statistic.html
+++ b/_includes/sc-statistic.html
@@ -7,3 +7,5 @@
   {%- if include.post -%}<div class="spotlight-component__caption-serif">{{ include.post }}</div>{%- endif -%}
 </div>
 {%- endif -%}
+
+{%- assign align_class = null -%}

--- a/_spotlights/introducing-a-new-arctic-ocean.md
+++ b/_spotlights/introducing-a-new-arctic-ocean.md
@@ -75,6 +75,14 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
+{% include sc-blockquote.html content='This is a test quote!' cite='JOHN DOE, Secretary of State' %}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+{% include sc-blockquote.html content='This is a test quote!' cite='JOHN DOE, Secretary of State' sizing="float-small" align='left' %}
+
 <h2 class="test-header" id="section-three">Section three</h2>
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
@@ -84,7 +92,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 <h2 class="test-header">Section four</h2>
 
-{% include sc-document.html align='right' url='https://csis-prod.s3.amazonaws.com/s3fs-public/publication/180924_Cognitive_Effect_Cyberspace.pdf?R6FPUdDaOystuUCWsMCXUhKTBg.4CW.D' label='The document title' caption='Feb. 24, 2016 (p. 45-78)' %}
+{% include sc-document.html align='right' url='https://csis-prod.s3.amazonaws.com/s3fs-public/publication/180924_Cognitive_Effect_Cyberspace.pdf?R6FPUdDaOystuUCWsMCXUhKTBg.4CW.D' label='The document title' caption='Feb. 24, 2016 (p. 45-78) "test"' %}
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 

--- a/assets/_sass/spotlights/components/_spotlights-components.scss
+++ b/assets/_sass/spotlights/components/_spotlights-components.scss
@@ -22,6 +22,33 @@
   }
 }
 
+/*=============================
+=                             =
+=          Blockquotes        =
+=                             =
+=============================*/
+
+.sc-blockquote {
+  position: relative;
+  @extend %post-content__caption;
+
+  &::after {
+    content: '';
+    display: block;
+    width: 80px;
+    height: 2px;
+    margin-top: 0.25rem;
+    border-top: 2px solid var(--accent-color);
+  }
+
+  cite {
+    margin-bottom: 0.5rem;
+    text-transform: none;
+
+    &::before { display: none; }
+  }
+}
+
 /*===========================
 =                           =
 =          Document         =


### PR DESCRIPTION
Closes #53 

I changed my opinion on how to implement this, and decided to make an include like the other components for consistencies sake. This one allows for both a sizing and an align parameter.

Note: Once variables are assigned anywhere on a page, including in an include, they will hold that value until they are reset. I added a reset value to all of the components that used the `size_class` and `align_class` to fix the behavior where an previous include would set that value and it would carry through to another include.