### PR TITLE
Fix/home

### DIFF
--- a/_includes/home-top.html
+++ b/_includes/home-top.html
@@ -58,8 +58,9 @@
             />
           </filter>
         </defs>
-        <text id="preserve" x="50%" y="50%">Preserve</text>
+        <!-- <text id="preserve" x="50%" y="50%">Preserve</text> -->
       </svg>
+      <div id="preserve">Preserve</div>
     </div>
 
     <div id="wave" data-per="0"></div>

--- a/_includes/home-top.html
+++ b/_includes/home-top.html
@@ -7,8 +7,7 @@
 
   <div id="hero_top">
     <div id="protect-svg">
-      <svg height="0" xmlns="http://www.w3.org/2000/svg">
-        <img class="hero-logo" src="{{ 'assets/images/logos/logo_blue_full.svg' | relative_url }}" alt="{{ site.title }}"
+      <img class="hero-logo" src="{{ 'assets/images/logos/logo_blue_full.svg' | relative_url }}" alt="{{ site.title }}"
         title="{{ site.title }}" />
         <div id="protect">
           <span>P</span>
@@ -19,16 +18,6 @@
           <span>c</span>
           <span>t</span>
         </div>
-        <defs>
-          <filter id="blur-filter" x="0" y="0">
-            <feGaussianBlur
-              id="gaussian-blur"
-              in="SourceGraphic"
-              stdDeviation="10"
-            />
-          </filter>
-        </defs>
-      </svg>
     </div>
 
     <div id="sky">
@@ -69,7 +58,7 @@
             />
           </filter>
         </defs>
-        <div id="preserve">Preserve</div>
+        <text id="preserve">Preserve</text>
       </svg>
     </div>
 

--- a/_includes/home-top.html
+++ b/_includes/home-top.html
@@ -58,7 +58,7 @@
             />
           </filter>
         </defs>
-        <text id="preserve">Preserve</text>
+        <text id="preserve" x="50%" y="50%">Preserve</text>
       </svg>
     </div>
 

--- a/assets/_js/home.js
+++ b/assets/_js/home.js
@@ -181,22 +181,22 @@ function InitWebGl() {
 
   count = count2 = blurcount = 0
 }
-
-let windowDur = 1
-const vTl = new TimelineMax(),
-  vT2 = new TimelineMax(),
-  vT3 = new TimelineMax(),
-  vT4 = new TimelineMax(),
-  vT5 = new TimelineMax(),
-  tl = new TimelineMax()
-let waterID = document.getElementById('water').offsetHeight
-const waterY = waterID + 100
-vTl
-  // .from(water_front, 5, { pixi: { alpha: 0, positionY: waterY }, delay: 4 }, 0)
-  .to('#clouds_1', 5, { y: '20' }, 0)
-  .to('#clouds_2', 5, { y: '15' }, '-=4')
-vT2.to('#turbwave', 4, { attr: { baseFrequency: 0.0 } }, 0)
 window.addEventListener('load', () => {
+  let windowDur = 1
+  const vTl = new TimelineMax(),
+    vT2 = new TimelineMax(),
+    vT3 = new TimelineMax(),
+    vT4 = new TimelineMax(),
+    vT5 = new TimelineMax(),
+    tl = new TimelineMax()
+  let waterID = document.getElementById('water').offsetHeight
+  const waterY = waterID + 100
+  vTl
+    // .from(water_front, 5, { pixi: { alpha: 0, positionY: waterY }, delay: 4 }, 0)
+    .to('#clouds_1', 5, { y: '20' }, 0)
+    .to('#clouds_2', 5, { y: '15' }, '-=4')
+  vT2.to('#turbwave', 4, { attr: { baseFrequency: 0.0 } }, 0)
+
   let ctrl = new ScrollMagic.Controller({
     globalSceneOptions: {}
   })
@@ -254,17 +254,17 @@ window.addEventListener('load', () => {
     .on('leave', function(event) {
       if (event.scrollDirection == 'FORWARD') {
         vT2.restart()
-        // TweenMax.to(window, windowDur, {
-        //   scrollTo: {
-        //     y: '#hero_bottom',
-        //     autoKill: false,
-        //     offsetY: -50
-        //   },
-        //   ease: Sine.easeOut
-        // })
-        // TweenMax.to('#protect', 1, { y: '300%', rotation: 0.001 })
+        TweenMax.to(window, windowDur, {
+          scrollTo: {
+            y: '#hero_bottom',
+            autoKill: false,
+            offsetY: -50
+          },
+          ease: Sine.easeOut
+        })
+        TweenMax.to('#protect', 1, { y: '300%', rotation: 0.001 })
         document.getElementById('home-scroll-container').classList.add('active')
-        // TweenMax.to('#hero_top', 1, { y: '35%', rotation: 0.001 }, '-=4')
+        TweenMax.to('#hero_top', 1, { y: '35%', rotation: 0.001 }, '-=4')
       } else {
         vT2.stop()
         document
@@ -288,7 +288,7 @@ window.addEventListener('load', () => {
     reverse: true // small offset added to prevent overscrolling accidentally triggering
   })
     .addTo(ctrl)
-    //.setTween(vT3)
+    .setTween(vT3)
     .on('leave', function(event) {
       vT2.stop()
       document.getElementById('preserve-svg').classList.remove('pactive')
@@ -296,15 +296,15 @@ window.addEventListener('load', () => {
         .getElementById('home-scroll-container')
         .classList.remove('active')
       if (event.scrollDirection == 'REVERSE') {
-        // TweenMax.to(window, windowDur, {
-        //   scrollTo: {
-        //     y: 0,
-        //     autoKill: false
-        //   },
-        //   ease: Sine.easeOut
-        // })
-        // TweenMax.to('#hero_top', 1, { y: '0%', rotation: 0.001 })
-        // TweenMax.to('#protect', 1, { y: '0%', rotation: 0.001 })
+        TweenMax.to(window, windowDur, {
+          scrollTo: {
+            y: 0,
+            autoKill: false
+          },
+          ease: Sine.easeOut
+        })
+        TweenMax.to('#hero_top', 1, { y: '0%', rotation: 0.001 })
+        TweenMax.to('#protect', 1, { y: '0%', rotation: 0.001 })
       }
     })
     .on('start', function(event) {

--- a/assets/_js/home.js
+++ b/assets/_js/home.js
@@ -1,159 +1,185 @@
 import * as PIXI from 'pixi.js'
 import TweenMax from 'TweenMax'
 import TimelineMax from 'TimelineMax'
+import TweenLite from 'TweenLite'
 import { PixiPlugin, ScrollToPlugin, Sine } from 'gsap/all'
 import Plyr from 'plyr'
 import ScrollMagic from 'ScrollMagic'
 import 'animation.gsap'
 
-let loader = PIXI.loader
+let loader
 let water_mesh, wave_mesh
 let water_originalVertices = []
 let wave_originalVertices = []
 
-loader
-  .add('/assets/images/home/water.png')
-  .add('/assets/images/home/water2.png')
-  .add('/assets/images/home/wave.png')
-  .add('/assets/images/home/dmap_waves.jpg')
-  .load()
-  .on('progress', loadProgressHandler)
-  .once('complete', start)
+let waterApp,
+  wavesApp,
+  container_water,
+  water_filter,
+  water_displacement,
+  water_bg,
+  water_front,
+  container_wave,
+  wave_front
 
-function loadProgressHandler(loader, resource) {
-  console.log('loading: ' + resource.url)
-}
-
-function createApp(id) {
-  let divID = document.getElementById(id)
-  let width = divID.offsetWidth
-  let height = divID.offsetHeight
-  let renderer = PIXI.autoDetectRenderer(width, height)
-
-  let app = new PIXI.Application(width, height, {
-    transparent: true
-  })
-  let stage = new PIXI.DisplayObjectContainer()
-  //app.autoResize = true;
-  divID.appendChild(app.view)
-
-  return [width, height, renderer, app, stage]
-}
-
-let waterApp = createApp('water')
-let wavesApp = createApp('wave')
-
-const container_water = new PIXI.Container()
-container_water.position.x = 0
-container_water.position.y = 0
-
-const water_filter = PIXI.Sprite.fromImage('/assets/images/home/dmap_waves.jpg')
-
-const water_displacement = new PIXI.filters.DisplacementFilter(water_filter)
-water_filter.texture.baseTexture.wrapMode = PIXI.WRAP_MODES.REPEAT
-container_water.filters = [water_displacement]
-water_filter.position.x = -20
-water_filter.scale.x = 1
-water_filter.scale.y = 1
-
-const water_bg = PIXI.Texture.fromImage('/assets/images/home/water.png')
-water_bg.on('update', function() {
-  if (water_mesh) {
-    container_water.removeChild(water_mesh)
-  }
-  water_mesh = new PIXI.mesh.Plane(this, 2, 4)
-  water_mesh.width = this.width //renderer.width * 0.35;
-  water_mesh.height = this.height //renderer.width * 0.5;
-  //console.log(this.height + " " + this.width);
-  container_water.addChildAt(water_mesh, 0)
-
-  water_originalVertices = water_mesh.vertices.slice(0)
-
-  const progress = document.getElementById('water').getAttribute('data-per')
-  water_mesh.vertices[5] = calculateV(
-    water_originalVertices[5],
-    progress * -0.2
-  )
-  water_mesh.vertices[7] = calculateV(
-    water_originalVertices[7],
-    progress * -0.2
-  )
-  water_mesh.vertices[9] = calculateV(
-    water_originalVertices[9],
-    progress * -0.4
-  )
-  water_mesh.vertices[11] = calculateV(
-    water_originalVertices[11],
-    progress * -0.4
-  )
-
-  function calculateV(v, n) {
-    let r = v + water_mesh.height * n
-    return r
-  }
-})
-
-const water_front = new PIXI.Sprite.fromImage('/assets/images/home/water2.png')
-water_front.width = waterApp[0] //renderer.width * 0.35;
-water_front.height = waterApp[1] / 1.5
-water_front.anchor.set(0.5, 1)
-water_front.x = waterApp[3].screen.width / 2
-water_front.y = waterApp[3].screen.height
-
-const container_wave = new PIXI.Container()
-container_wave.position.x = 0
-container_wave.position.y = 0
-container_wave.pivot.x = container_wave.width * 0.4
-container_wave.pivot.y = container_wave.height * -0.3
-
-let wave_front = new PIXI.Texture.fromImage('/assets/images/home/wave.png')
-wave_front.on('update', function() {
-  if (wave_mesh) {
-    container_wave.removeChild(wave_mesh)
-  }
-  wave_mesh = new PIXI.mesh.Plane(this, 20, 5)
-
-  wave_mesh.width = waterApp[0] //renderer.width * 0.35;
-  wave_mesh.height = 300 //renderer.width * 0.5;
-  container_wave.addChild(wave_mesh) //, 0);
-  //t_mesh.pivot.x = t_mesh.width * 0.4;
-  wave_mesh.pivot.y = wave_mesh.height * -0.3
-
-  wave_originalVertices = wave_mesh.vertices.slice(0)
-  animate()
-})
-
-animate()
 let count, count2, blurcount
-count = count2 = blurcount = 0
 
-function animate() {
-  count = 0.7
-  count2 += 0.03
-  blurcount += 0.005
+let req, last, timeDiff, smoothRendering
 
-  water_filter.x += 1
-  water_filter.y += 0
-
-  if (wave_mesh && wave_mesh.vertices) {
-    for (let i = 0; i < 200; i++) {
-      if (i % 2 !== 0) {
-        wave_mesh.vertices[i] =
-          wave_originalVertices[i] + 50 * Math.cos(count2 + i * 0.1)
-      }
-    }
+function fpsMeasureLoop(timestamp) {
+  if (last) {
+    timeDiff = timestamp - last
   }
 
-  requestAnimationFrame(animate)
-  waterApp[2].render(waterApp[4])
-  wavesApp[2].render(wavesApp[4])
+  if (timeDiff > 55) {
+    // change to 0 instead of 55 to see hero without pixi activated
+    smoothRendering = false
+  } else {
+    smoothRendering = true
+  }
+
+  last = timestamp
+  req = requestAnimationFrame(fpsMeasureLoop)
 }
 
-function start() {
-  waterApp[3].stage.addChild(container_water)
-  container_water.addChild(water_front) //, 0);
-  container_water.addChild(water_filter)
-  wavesApp[3].stage.addChild(container_wave)
+req = requestAnimationFrame(fpsMeasureLoop)
+
+let canvas = document.createElement('canvas')
+let webglSupported =
+  !!canvas.getContext('webgl') || !!canvas.getContext('experimental-webgl')
+
+water_bg = document.querySelector('#water')
+water_bg.style.backgroundImage = `url("/assets/images/home/water2.png"),url("/assets/images/home/water.png")`
+water_bg.style.backgroundPositionY = `120%,0%`
+water_bg.style.backgroundRepeat = `no-repeat`
+
+wave_front = document.querySelector('#wave')
+wave_front.style.backgroundImage = `url(/assets/images/home/wave.png)`
+wave_front.style.backgroundPositionY = `15%`
+wave_front.style.backgroundRepeat = `no-repeat`
+
+setTimeout(() => {
+  cancelAnimationFrame(req)
+
+  if (smoothRendering && webglSupported) {
+    InitWebGl()
+    document.querySelector('#water').style.backgroundImage = `none`
+    document.querySelector('#wave').style.backgroundImage = `none`
+  } else {
+    document.querySelector('#preserve').style.filter = 'none'
+    document.querySelector('#preserve-svg').classList.add('disable-animation')
+
+    Array.from(document.querySelectorAll('#protect span')).forEach(element => {
+      element.style.filter = 'none'
+      element.style.transform = 'none'
+      element.style.opacity = '1'
+    })
+
+    Array.from(document.querySelectorAll('.ray')).forEach(element => {
+      element.style.filter = 'none'
+      element.style.opacity = '.33'
+      element.classList.add('disable-animation')
+    })
+  }
+}, 2000)
+
+function InitWebGl() {
+  loader = PIXI.loader
+
+  loader
+    .add('/assets/images/home/water.png')
+    .add('/assets/images/home/water2.png')
+    .add('/assets/images/home/wave.png')
+    .add('/assets/images/home/dmap_waves.jpg')
+    .load()
+    .on('progress', loadProgressHandler)
+    .once('complete', start)
+
+  waterApp = createApp('water')
+  wavesApp = createApp('wave')
+
+  container_water = new PIXI.Container()
+  container_water.position.x = 0
+  container_water.position.y = 0
+
+  water_filter = PIXI.Sprite.fromImage('/assets/images/home/dmap_waves.jpg')
+
+  water_displacement = new PIXI.filters.DisplacementFilter(water_filter)
+  water_filter.texture.baseTexture.wrapMode = PIXI.WRAP_MODES.REPEAT
+  container_water.filters = [water_displacement]
+  water_filter.position.x = -20
+  water_filter.scale.x = 1
+  water_filter.scale.y = 1
+
+  water_bg = PIXI.Texture.fromImage('/assets/images/home/water.png')
+  water_bg.on('update', function() {
+    if (water_mesh) {
+      container_water.removeChild(water_mesh)
+    }
+    water_mesh = new PIXI.mesh.Plane(this, 2, 4)
+    water_mesh.width = this.width //renderer.width * 0.35;
+    water_mesh.height = this.height //renderer.width * 0.5;
+    //console.log(this.height + " " + this.width);
+    container_water.addChildAt(water_mesh, 0)
+
+    water_originalVertices = water_mesh.vertices.slice(0)
+
+    const progress = document.getElementById('water').getAttribute('data-per')
+    water_mesh.vertices[5] = calculateV(
+      water_originalVertices[5],
+      progress * -0.2
+    )
+    water_mesh.vertices[7] = calculateV(
+      water_originalVertices[7],
+      progress * -0.2
+    )
+    water_mesh.vertices[9] = calculateV(
+      water_originalVertices[9],
+      progress * -0.4
+    )
+    water_mesh.vertices[11] = calculateV(
+      water_originalVertices[11],
+      progress * -0.4
+    )
+
+    function calculateV(v, n) {
+      let r = v + water_mesh.height * n
+      return r
+    }
+  })
+
+  water_front = new PIXI.Sprite.fromImage('/assets/images/home/water2.png')
+  water_front.width = waterApp[0] //renderer.width * 0.35;
+  water_front.height = waterApp[1] / 1.5
+  water_front.anchor.set(0.5, 1)
+  water_front.x = waterApp[3].screen.width / 2
+  water_front.y = waterApp[3].screen.height
+
+  container_wave = new PIXI.Container()
+  container_wave.position.x = 0
+  container_wave.position.y = 0
+  container_wave.pivot.x = container_wave.width * 0.4
+  container_wave.pivot.y = container_wave.height * -0.3
+
+  wave_front = new PIXI.Texture.fromImage('/assets/images/home/wave.png')
+  wave_front.on('update', function() {
+    if (wave_mesh) {
+      container_wave.removeChild(wave_mesh)
+    }
+    wave_mesh = new PIXI.mesh.Plane(this, 20, 5)
+
+    wave_mesh.width = waterApp[0] //renderer.width * 0.35;
+    wave_mesh.height = 400 //renderer.width * 0.5;
+    container_wave.addChild(wave_mesh) //, 0);
+    //t_mesh.pivot.x = t_mesh.width * 0.4;
+    wave_mesh.pivot.y = wave_mesh.height * -0.3
+
+    wave_originalVertices = wave_mesh.vertices.slice(0)
+  })
+
+  animate()
+
+  count = count2 = blurcount = 0
 }
 
 let windowDur = 1
@@ -166,7 +192,7 @@ const vTl = new TimelineMax(),
 let waterID = document.getElementById('water').offsetHeight
 const waterY = waterID + 100
 vTl
-  .from(water_front, 5, { pixi: { alpha: 0, positionY: waterY }, delay: 4 }, 0)
+  // .from(water_front, 5, { pixi: { alpha: 0, positionY: waterY }, delay: 4 }, 0)
   .to('#clouds_1', 5, { y: '20' }, 0)
   .to('#clouds_2', 5, { y: '15' }, '-=4')
 vT2.to('#turbwave', 4, { attr: { baseFrequency: 0.0 } }, 0)
@@ -175,27 +201,31 @@ window.addEventListener('load', () => {
     globalSceneOptions: {}
   })
   vT5.to('#sky', 4, { y: '20%' }, 0)
-  vT4.staggerFromTo(
-    '#protect span',
-    0.7,
-    {
-      transform: 'matrix(1.1, 0.2, 0.2, 0.8, -20, -00)',
-      autoAlpha: 0,
-      webKitFilter: 'blur(5px)',
-      filter: 'blur(5px)',
-      x: -80,
-      rotation: 0.01
-    },
-    {
-      autoAlpha: 1,
-      webKitFilter: 'blur(0px)',
-      filter: 'blur(0px)',
-      x: 0,
-      rotation: 0.01,
-      transform: 'matrix(1, 0, 0, 1, 0, 1)'
-    },
-    0.1
-  )
+
+  if (smoothRendering && webglSupported) {
+    vT4.staggerFromTo(
+      '#protect span',
+      0.7,
+      {
+        transform: 'matrix(1.1, 0.2, 0.2, 0.8, -20, -00)',
+        autoAlpha: 0,
+        webKitFilter: 'blur(5px)',
+        filter: 'blur(5px)',
+        x: -80,
+        rotation: 0.01
+      },
+      {
+        autoAlpha: 1,
+        webKitFilter: 'blur(0px)',
+        filter: 'blur(0px)',
+        x: 0,
+        rotation: 0.01,
+        transform: 'matrix(1, 0, 0, 1, 0, 1)'
+      },
+      0.1
+    )
+  }
+
   new ScrollMagic.Scene({
     triggerHook: 'onEnter',
     triggerElement: '#hero_bottom',
@@ -219,7 +249,7 @@ window.addEventListener('load', () => {
       document
         .getElementById('water')
         .setAttribute('data-per', e.progress.toFixed(3))
-      water_bg.update()
+      // water_bg.update()
     })
     .on('leave', function(event) {
       if (event.scrollDirection == 'FORWARD') {
@@ -283,3 +313,52 @@ window.addEventListener('load', () => {
 
   const player = new Plyr('#home-video')
 }) //window onload
+
+function loadProgressHandler(loader, resource) {
+  console.log('loading: ' + resource.url)
+}
+
+function createApp(id) {
+  let divID = document.getElementById(id)
+  let width = divID.offsetWidth
+  let height = divID.offsetHeight
+  let renderer = PIXI.autoDetectRenderer(width, height)
+
+  let app = new PIXI.Application(width, height, {
+    transparent: true
+  })
+  let stage = new PIXI.DisplayObjectContainer()
+  app.autoResize = true
+  divID.appendChild(app.view)
+
+  return [width, height, renderer, app, stage]
+}
+
+function animate() {
+  count = 0.7
+  count2 += 0.03
+  blurcount += 0.005
+
+  water_filter.x += 1
+  water_filter.y += 0
+
+  if (wave_mesh && wave_mesh.vertices) {
+    for (let i = 0; i < 200; i++) {
+      if (i % 2 !== 0) {
+        wave_mesh.vertices[i] =
+          wave_originalVertices[i] + 50 * Math.cos(count2 + i * 0.1)
+      }
+    }
+  }
+
+  requestAnimationFrame(animate)
+  waterApp[2].render(waterApp[4])
+  wavesApp[2].render(wavesApp[4])
+}
+
+function start() {
+  waterApp[3].stage.addChild(container_water)
+  container_water.addChild(water_front) //, 0);
+  container_water.addChild(water_filter)
+  wavesApp[3].stage.addChild(container_wave)
+}

--- a/assets/_js/home.js
+++ b/assets/_js/home.js
@@ -96,7 +96,7 @@ water_bg.on('update', function() {
 const water_front = new PIXI.Sprite.fromImage('/assets/images/home/water2.png')
 water_front.width = waterApp[0] //renderer.width * 0.35;
 water_front.height = waterApp[1] / 1.5
-water_front.anchor.set(0.5, 1.0)
+water_front.anchor.set(0.5, 1)
 water_front.x = waterApp[3].screen.width / 2
 water_front.y = waterApp[3].screen.height
 
@@ -114,7 +114,7 @@ wave_front.on('update', function() {
   wave_mesh = new PIXI.mesh.Plane(this, 20, 5)
 
   wave_mesh.width = waterApp[0] //renderer.width * 0.35;
-  wave_mesh.height = 400 //renderer.width * 0.5;
+  wave_mesh.height = 300 //renderer.width * 0.5;
   container_wave.addChild(wave_mesh) //, 0);
   //t_mesh.pivot.x = t_mesh.width * 0.4;
   wave_mesh.pivot.y = wave_mesh.height * -0.3
@@ -200,7 +200,7 @@ window.addEventListener('load', () => {
     triggerHook: 'onEnter',
     triggerElement: '#hero_bottom',
     duration: '100%',
-    offset: 10
+    offset: 0
   })
     .addTo(ctrl)
     .setTween(vT5)
@@ -209,7 +209,7 @@ window.addEventListener('load', () => {
     triggerHook: 'onLeave',
     triggerElement: '#hero_top',
     duration: '20%',
-    offset: 10
+    offset: 0
   })
     .setPin('#hero_top')
     .setTween(vTl)
@@ -224,17 +224,17 @@ window.addEventListener('load', () => {
     .on('leave', function(event) {
       if (event.scrollDirection == 'FORWARD') {
         vT2.restart()
-        TweenMax.to(window, windowDur, {
-          scrollTo: {
-            y: '#hero_bottom',
-            autoKill: false,
-            offsetY: -50
-          },
-          ease: Sine.easeOut
-        })
-        TweenMax.to('#protect', 1, { y: '300%', rotation: 0.001 })
+        // TweenMax.to(window, windowDur, {
+        //   scrollTo: {
+        //     y: '#hero_bottom',
+        //     autoKill: false,
+        //     offsetY: -50
+        //   },
+        //   ease: Sine.easeOut
+        // })
+        // TweenMax.to('#protect', 1, { y: '300%', rotation: 0.001 })
         document.getElementById('home-scroll-container').classList.add('active')
-        TweenMax.to('#hero_top', 1, { y: '35%', rotation: 0.001 }, '-=4')
+        // TweenMax.to('#hero_top', 1, { y: '35%', rotation: 0.001 }, '-=4')
       } else {
         vT2.stop()
         document
@@ -266,15 +266,15 @@ window.addEventListener('load', () => {
         .getElementById('home-scroll-container')
         .classList.remove('active')
       if (event.scrollDirection == 'REVERSE') {
-        TweenMax.to(window, windowDur, {
-          scrollTo: {
-            y: 0,
-            autoKill: false
-          },
-          ease: Sine.easeOut
-        })
-        TweenMax.to('#hero_top', 1, { y: '0%', rotation: 0.001 })
-        TweenMax.to('#protect', 1, { y: '0%', rotation: 0.001 })
+        // TweenMax.to(window, windowDur, {
+        //   scrollTo: {
+        //     y: 0,
+        //     autoKill: false
+        //   },
+        //   ease: Sine.easeOut
+        // })
+        // TweenMax.to('#hero_top', 1, { y: '0%', rotation: 0.001 })
+        // TweenMax.to('#protect', 1, { y: '0%', rotation: 0.001 })
       }
     })
     .on('start', function(event) {

--- a/assets/_js/home.js
+++ b/assets/_js/home.js
@@ -1,3 +1,4 @@
+import Breakpoints from './breakpoints'
 import * as PIXI from 'pixi.js'
 import TweenMax from 'TweenMax'
 import TimelineMax from 'TimelineMax'
@@ -49,22 +50,22 @@ let webglSupported =
   !!canvas.getContext('webgl') || !!canvas.getContext('experimental-webgl')
 
 water_bg = document.querySelector('#water')
-water_bg.style.backgroundImage = `url("/assets/images/home/water2.png"),url("/assets/images/home/water.png")`
-water_bg.style.backgroundPositionY = `120%,0%`
-water_bg.style.backgroundRepeat = `no-repeat`
+// water_bg.style.backgroundImage = `url("/assets/images/home/water2.png"),url("/assets/images/home/water.png")`
+// water_bg.style.backgroundPositionY = `120%,0%`
+// water_bg.style.backgroundRepeat = `no-repeat`
 
 wave_front = document.querySelector('#wave')
-wave_front.style.backgroundImage = `url(/assets/images/home/wave.png)`
-wave_front.style.backgroundPositionY = `15%`
-wave_front.style.backgroundRepeat = `no-repeat`
+// wave_front.style.backgroundImage = `url(/assets/images/home/wave.png)`
+// wave_front.style.backgroundPositionY = `15%`
+// wave_front.style.backgroundRepeat = `no-repeat`
 
 setTimeout(() => {
   cancelAnimationFrame(req)
 
   if (smoothRendering && webglSupported) {
     InitWebGl()
-    document.querySelector('#water').style.backgroundImage = `none`
-    document.querySelector('#wave').style.backgroundImage = `none`
+    // document.querySelector('#water').style.backgroundImage = `none`
+    // document.querySelector('#wave').style.backgroundImage = `none`
   } else {
     document.querySelector('#preserve').style.filter = 'none'
     document.querySelector('#preserve-svg').classList.add('disable-animation')
@@ -81,9 +82,13 @@ setTimeout(() => {
       element.classList.add('disable-animation')
     })
   }
-}, 2000)
+}, 500)
 
 function InitWebGl() {
+  if (Breakpoints.isMobile()) {
+    return
+  }
+
   loader = PIXI.loader
 
   loader

--- a/assets/_sass/components/_home-top.scss
+++ b/assets/_sass/components/_home-top.scss
@@ -147,15 +147,9 @@
   }
 
   #preserve {
-    @include font-size(80px);
-    text-anchor: middle;
+    color: $color__white;
     filter: url('#turb');
-    dominant-baseline: hanging;
     fill: $color__white;
-
-    @include breakpoint('medium') {
-      @include font-size(60px);
-    }
   }
 
   #preserve-svg,
@@ -170,6 +164,10 @@
 
     @include breakpoint('large') {
       @include font-size(120px);
+    }
+
+    svg {
+      display: none;
     }
   }
 

--- a/assets/_sass/components/_home-top.scss
+++ b/assets/_sass/components/_home-top.scss
@@ -5,6 +5,7 @@
     left: 50%;
     width: 100vw;
     margin: 0 -50vw;
+    background-color: #f0f2f6;
   }
 
   #px-render {
@@ -87,12 +88,29 @@
   }
 
   #water {
+    position: relative;
     height: 60vh;
     background: url('#{$img__home}water2.png'), url('#{$img__home}water.png');
     background-repeat: no-repeat;
 
     @include breakpoint('medium') {
       background-position-y: 120%, 0%;
+    }
+
+    &::after {
+      @include breakpoint('xlarge-2') {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 1499px;
+        display: block;
+        width: 1500px;
+        height: 100%;
+        background: url('#{$img__home}water2.png'), url('#{$img__home}water.png');
+        background-repeat: no-repeat;
+        background-position-y: 120%,0;
+        transform: scaleX(-1);
+      }
     }
   }
 
@@ -109,6 +127,23 @@
     background-repeat: no-repeat;
     background-position-y: 15%;
     transition: left 1s ease-in-out;
+
+    &::after {
+      @include breakpoint('xlarge-2') {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 1499px;
+        display: block;
+        width: 1500px;
+        height: 100%;
+        background: url('#{$img__home}wave.png');
+        background-repeat: no-repeat;
+        background-position-y: 15%;
+        transform: scaleX(-1);
+        transition: left 1s ease-in-out;
+      }
+    }
   }
 
   #preserve {

--- a/assets/_sass/components/_home-top.scss
+++ b/assets/_sass/components/_home-top.scss
@@ -1,4 +1,3 @@
-
 .layout-home {
   .home__hero {
     position: relative;
@@ -44,7 +43,7 @@
       @include breakpoint('large') {
         max-width: 500px;
       }
-    }  
+    }
   }
 
   #hero_bottom {
@@ -104,8 +103,12 @@
   }
 
   #preserve {
-    color: $color__white;
+    @include font-size(60px);
+    text-anchor: middle;
+    transform: translate(50%, 50%);
     filter: url('#turb');
+    dominant-baseline: hanging;
+    fill: $color__white;
   }
 
   #preserve-svg,
@@ -138,7 +141,7 @@
 
     &.pactive {
       position: absolute;
-      top: -40%;
+      top: 20%;
       opacity: 1;
       transition: opacity 3s, top 1s;
     }
@@ -146,14 +149,14 @@
 
   #protect-svg {
     position: fixed;
-    top: 0;
+    top: 33%;
     letter-spacing: -0.75rem;
     opacity: 1;
     transition: opacity 2s, top 2s;
 
-    @media screen and (min-height: 800px) {
-      top: 15vh;
-    }    
+    // @media screen and (min-height: 800px) {
+    //   top: 15vh;
+    // }
   }
 
   #hero_bottom::before {
@@ -215,6 +218,7 @@
 
   #underwater-container {
     height: 80vh;
+    min-height: 800px;
     background: #0e2764;
     background: linear-gradient(
       75deg,
@@ -227,7 +231,6 @@
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0e2764', endColorstr='#1d509b', GradientType=1);
     // filter: blur(6px);
     // animation: Gradient 5s ease infinite;
-  
 
     &::after {
       position: absolute;
@@ -307,7 +310,7 @@
   @for $i from 1 through 4 {
     $time: ($i / 2 + 2);
     $time1: $time + s;
-    
+
     .ray:nth-child(#{$i}):not(.disable-animation) {
       animation: move-#{$i} $time1 linear infinite alternate;
     }

--- a/assets/_sass/components/_home-top.scss
+++ b/assets/_sass/components/_home-top.scss
@@ -88,6 +88,12 @@
 
   #water {
     height: 60vh;
+    background: url('#{$img__home}water2.png'), url('#{$img__home}water.png');
+    background-repeat: no-repeat;
+
+    @include breakpoint('medium') {
+      background-position-y: 120%, 0%;
+    }
   }
 
   #wave {
@@ -99,6 +105,9 @@
     height: 100vh;
     margin-top: -20vh;
     overflow: hidden;
+    background: url('#{$img__home}wave.png');
+    background-repeat: no-repeat;
+    background-position-y: 15%;
     transition: left 1s ease-in-out;
   }
 

--- a/assets/_sass/components/_home-top.scss
+++ b/assets/_sass/components/_home-top.scss
@@ -1,7 +1,3 @@
-.site-footer {
-  z-index: 2;
-  position: relative;
-}
 
 .layout-home {
   .home__hero {
@@ -37,8 +33,8 @@
       rgba(208, 216, 224, 1) 51%,
       rgba(158, 179, 208, 1) 100%
     );
-<<<<<<< HEAD
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f2f6', endColorstr='#9eb3d0', GradientType=1);
+
+    //filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f2f6', endColorstr='#9eb3d0', GradientType=1);
 
     .hero-logo {
       display: block;
@@ -49,9 +45,6 @@
         max-width: 500px;
       }
     }  
-=======
-    // filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f2f6', endColorstr='#9eb3d0', GradientType=1);
->>>>>>> no-webgl/slow-fps fallback
   }
 
   #hero_bottom {
@@ -132,19 +125,16 @@
 
   #preserve-svg {
     position: absolute;
-<<<<<<< HEAD
     top: -60%;
     letter-spacing: 0.25rem;
     opacity: 0;
     transition: opacity 0.5s, top 1s;
-=======
 
     &:not(.disable-animation) {
       top: -20%;
       opacity: 0;
       transition: opacity 0.5s, top 1s;
     }
->>>>>>> no-webgl/slow-fps fallback
 
     &.pactive {
       position: absolute;
@@ -224,7 +214,6 @@
   }
 
   #underwater-container {
-    filter: blur(6px);
     height: 80vh;
     background: #0e2764;
     background: linear-gradient(
@@ -236,7 +225,9 @@
       #1d509b 93%
     );
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0e2764', endColorstr='#1d509b', GradientType=1);
+    // filter: blur(6px);
     // animation: Gradient 5s ease infinite;
+  
 
     &::after {
       position: absolute;
@@ -316,6 +307,7 @@
   @for $i from 1 through 4 {
     $time: ($i / 2 + 2);
     $time1: $time + s;
+    
     .ray:nth-child(#{$i}):not(.disable-animation) {
       animation: move-#{$i} $time1 linear infinite alternate;
     }

--- a/assets/_sass/components/_home-top.scss
+++ b/assets/_sass/components/_home-top.scss
@@ -1,3 +1,8 @@
+.site-footer {
+  z-index: 2;
+  position: relative;
+}
+
 .layout-home {
   .home__hero {
     position: relative;
@@ -18,6 +23,7 @@
   }
 
   #hero_top {
+    // position: relative !important;
     z-index: 2;
     display: flex;
     flex-direction: column;
@@ -31,6 +37,7 @@
       rgba(208, 216, 224, 1) 51%,
       rgba(158, 179, 208, 1) 100%
     );
+<<<<<<< HEAD
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f2f6', endColorstr='#9eb3d0', GradientType=1);
 
     .hero-logo {
@@ -42,6 +49,9 @@
         max-width: 500px;
       }
     }  
+=======
+    // filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f2f6', endColorstr='#9eb3d0', GradientType=1);
+>>>>>>> no-webgl/slow-fps fallback
   }
 
   #hero_bottom {
@@ -122,10 +132,19 @@
 
   #preserve-svg {
     position: absolute;
+<<<<<<< HEAD
     top: -60%;
     letter-spacing: 0.25rem;
     opacity: 0;
     transition: opacity 0.5s, top 1s;
+=======
+
+    &:not(.disable-animation) {
+      top: -20%;
+      opacity: 0;
+      transition: opacity 0.5s, top 1s;
+    }
+>>>>>>> no-webgl/slow-fps fallback
 
     &.pactive {
       position: absolute;
@@ -196,7 +215,7 @@
 
   #protect-svg span {
     display: inline-block;
-    text-shadow: 0 0 0 $color__white;
+    // text-shadow: 0 0 0 $color__white;
     transform: matrix(0.9, 0.3, 0, 0.4, -100, -100);
     transform-origin: 0 0;
     opacity: 0;
@@ -205,6 +224,7 @@
   }
 
   #underwater-container {
+    filter: blur(6px);
     height: 80vh;
     background: #0e2764;
     background: linear-gradient(
@@ -216,7 +236,7 @@
       #1d509b 93%
     );
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0e2764', endColorstr='#1d509b', GradientType=1);
-    animation: Gradient 5s ease infinite;
+    // animation: Gradient 5s ease infinite;
 
     &::after {
       position: absolute;
@@ -260,7 +280,7 @@
     transform: scale(1) rotate(0) translateX(0) translateY(0) skewX(30deg)
       skewY(0deg);
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00ffffff', endColorstr='#00ffffff', GradientType=0);
-    filter: blur(6px);
+    // filter: blur(6px);
     transition: all 1000ms ease;
   }
 
@@ -279,7 +299,7 @@
       rgba(255, 255, 255, 0) 100%
     );
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00ffffff', endColorstr='#00ffffff', GradientType=0); /* IE6-9 */
-    filter: blur(10px);
+    // filter: blur(10px);
     content: '';
   }
 
@@ -296,17 +316,16 @@
   @for $i from 1 through 4 {
     $time: ($i / 2 + 2);
     $time1: $time + s;
-
-    .ray:nth-child(#{$i}) {
+    .ray:nth-child(#{$i}):not(.disable-animation) {
       animation: move-#{$i} $time1 linear infinite alternate;
     }
 
-    .ray:nth-child(#{$i})::before {
+    .ray:nth-child(#{$i}):not(.disable-animation)::before {
       width: random(100) + px;
       animation: move-#{$i} 5s linear infinite alternate;
     }
 
-    .ray:nth-child(#{$i})::after {
+    .ray:nth-child(#{$i}):not(.disable-animation)::after {
       width: random(100) + px;
       animation: move-#{$i} 3s linear infinite alternate;
     }

--- a/assets/_sass/components/_home-top.scss
+++ b/assets/_sass/components/_home-top.scss
@@ -112,12 +112,15 @@
   }
 
   #preserve {
-    @include font-size(60px);
+    @include font-size(80px);
     text-anchor: middle;
-    transform: translate(50%, 50%);
     filter: url('#turb');
     dominant-baseline: hanging;
     fill: $color__white;
+
+    @include breakpoint('medium') {
+      @include font-size(60px);
+    }
   }
 
   #preserve-svg,
@@ -388,12 +391,18 @@
     p {
       max-width: 800px;
       margin: 0 auto;
+      padding: 0 20px;
       color: $color__white;
       font-family: $font__freight;
-      @include font-size(40px);
+      @include font-size(30px);
       font-style: italic;
       line-height: 1.3;
       text-align: center;
+
+      @include breakpoint('medium') {
+        @include font-size(40px);
+        padding: 0;
+      }
     }
   }
 


### PR DESCRIPTION
An attempt to put in a fallback for browsers without webgl or computers with slower graphics cards. 
I thought I was uniquely positioned to take a stab at this because the home page isn't really working on my laptop (2012 retina pro) and because I'd looked at ways to detect graphics card quality during my mapbox fiasco. I started by commenting a lot of the problem code. I left TweenMax.to and scrollTo commented out because they were an absolute disaster on my laptop. I suppose those could get put back under a condition stored in a variable called "smoothRendering." I also still have a lot of scss commented out because the gradients and blur filters were taking a long time to render, leaving half my screen dark blue and half light blue at moments. The css animations/transitions were also a problem so I have those active only under the "smoothRendering" condition or with an added class called ".disable-animation" that has been also added to the scss.