### PR TITLE
Fix/about page

### DIFF
--- a/_data/language.yml
+++ b/_data/language.yml
@@ -34,6 +34,6 @@ is_featured: 'Featured '
 search_placeholder: Search
 search_title: Search result for
 authors_title: 'Articles by: '
-ilab: "The Stephenson Ocean Security Project is a product of the [**Andreas C. Dracopoulos iDeas Lab**](https://www.csis.org/programs/dracopoulos-ideas-lab), the in-house digital, multimedia, and design agency at the Center for Strategic and International Studies."
+ilab: "The Stephenson Ocean Security Project is a product of the [**Andreas C. Dracopoulos iDeas Lab**](https://www.csis.org/programs/dracopoulos-ideas-lab), the in-house digital, multimedia, and design agency at the Center for Strategic and International Studies. \ Special thanks to creative leads [**Jacque Schrag**](https://www.csis.org/people/jacqueline-schrag) and [**Tucker Harris**](https://www.csis.org/people/tucker-harris), and for their work developing and designing the website."
 the_team: The Team
 development_team: Creative and Development Team

--- a/_data/language.yml
+++ b/_data/language.yml
@@ -36,4 +36,4 @@ search_title: Search result for
 authors_title: 'Articles by: '
 ilab: "The Stephenson Ocean Security Project is a product of the [**Andreas C. Dracopoulos iDeas Lab**](https://www.csis.org/programs/dracopoulos-ideas-lab), the in-house digital, multimedia, and design agency at the Center for Strategic and International Studies."
 the_team: The Team
-development_team: Development Team
+development_team: Creative and Development Team

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -11,10 +11,11 @@ layout: default
     {%- include social-share.html class="post__header" -%}
   </header>
   <section class="post__content e-content" itemprop="articleBody">
+    <p class="post-lede">{{ page.mission_statement | markdownify }}</p>
     <div class="post__content-body post-content">{{ content }}</div>
 
     {%-if page.name=="about.md" -%}
-    <div class="about">
+    <div class=" about">
       <h2>{{ site.data.language.the_team }}</h2>
         {%- for person in page.team -%}
         <div class="about-person">
@@ -30,9 +31,8 @@ layout: default
       <h3>{{ site.data.language.development_team }}</h3>
       <p>{{ site.data.language.ilab | markdownify }}</p>
     </div>
-
     {%- endif -%}
-    
+
   </section>
   <footer class="post__footer">
     <section class="post__footer-top">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -15,7 +15,7 @@ layout: default
     <div class="post__content-body post-content">{{ content }}</div>
 
     {%-if page.name=="about.md" -%}
-    <div class=" about">
+    <div class="about">
       <h2>{{ site.data.language.the_team }}</h2>
         {%- for person in page.team -%}
         <div class="about-person">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -11,7 +11,7 @@ layout: default
     {%- include social-share.html class="post__header" -%}
   </header>
   <section class="post__content e-content" itemprop="articleBody">
-    <p class="post-lede">{{ page.mission_statement | markdownify }}</p>
+    <p class="post-lede">{{ page.mission_statement | replace: '***', "</br></br>" }}</p>
     <div class="post__content-body post-content">{{ content }}</div>
 
     {%-if page.name=="about.md" -%}
@@ -23,8 +23,7 @@ layout: default
           <h3 class="about-heading">{{ person.name }}</h3>
           <div class="about-subheading">{{ person.title }}</div>
           <img src="{{ person.headshot | relative_url }}" alt="{{ person.name | escape }}" title="{{ person.name | escape }}" />
-
-          <p class="about-bio">{{ person.bio }}</p>
+          {{ person.bio | markdownify }}
 
         </div>
         {%- endfor -%}

--- a/about.md
+++ b/about.md
@@ -5,7 +5,7 @@ permalink: "/about/"
 team:
 - name: Dr. Whitley Saumweber
   title: Director
-  headshot: https://res.cloudinary.com/csisideaslab/image/upload/v1545689230/ocean/5Whit_9.jpg
+  headshot: https://res.cloudinary.com/csisideaslab/image/upload/v1546549798/ocean/saumweber-headshot.jpg
   bio: Dr. [**Whitley Saumweber**](https://www.csis.org/people/whitley-saumweber) is director of the Stephenson Ocean Security Project
     at the Center for Strategic and International Studies. He has worked extensively
     across the federal government, academia, and private sector developing practical
@@ -26,7 +26,7 @@ team:
     Rhode Island.
 - name: Monica Medina
   title: Senior Associate
-  headshot: https://res.cloudinary.com/csisideaslab/image/upload/v1546548140/ocean/Monica_Medina-1.jpg
+  headshot: https://res.cloudinary.com/csisideaslab/image/upload/v1546547720/ocean/medina-headshot.jpg
   bio: '[**Monica Medina**](https://www.csis.org/people/monica-medina) is the founder and publisher of Our Daily Planet, an environmental e-mail newsletter, and an independent consultant. She is also an adjunct professor in the School of Foreign Service at Georgetown University. Previously, Ms. Medina served as deputy director of the Environment Program at the Walton Family Foundation, and she was senior director of ocean policy at the National Geographic Society. From 2012 to 2013, she served as special assistant to the secretary of defense. Earlier, she served as principal deputy undersecretary of commerce for oceans and atmosphere at the National Oceanic and Atmospheric Administration, where she led efforts on Arctic conservation and restoration of the Gulf of Mexico after the Deepwater Horizon oil spill.'
 mission_statement: |-
   The Stephenson Ocean Security (SOS) Project examines the intersection of ocean health and global security. It proposes policy solutions that support sustainable development and reduce conflict.

--- a/about.md
+++ b/about.md
@@ -5,8 +5,8 @@ permalink: "/about/"
 team:
 - name: Dr. Whitley Saumweber
   title: Director
-  headshot: https://res.cloudinary.com/csisideaslab/image/upload/c_limit,h_512,w_512/v1545689230/ocean/5Whit_9.jpg
-  bio: Dr. Whitley Saumweber is director of the Stephenson Ocean Security Project
+  headshot: https://res.cloudinary.com/csisideaslab/image/upload/v1545689230/ocean/5Whit_9.jpg
+  bio: Dr. [**Whitley Saumweber**](https://www.csis.org/people/whitley-saumweber) is director of the Stephenson Ocean Security Project
     at the Center for Strategic and International Studies. He has worked extensively
     across the federal government, academia, and private sector developing practical
     approaches for integrating marine science with pressing policy needs. He has been
@@ -26,25 +26,12 @@ team:
     Rhode Island.
 - name: Monica Medina
   title: Senior Associate
-  headshot: https://res.cloudinary.com/csisideaslab/image/upload/c_limit,h_512,w_512/v1544462781/ocean/medina-headshot-test.png
-  bio: 'Monica Medina is a small business owner; she is the Founder and Publisher
-    or Our Daily Planet, an environmental e-mail newsletter, and an independent consultant.  Medina
-    is also an Adjunct Professor in the School of Foreign Service at Georgetown University.
-    Previously Medina served as the Deputy Director of the Environment Program at
-    the Walton Family Foundation, and she was the Senior Director of Ocean Policy
-    at the National Geographic Society.  From 2012-2013, Ms. Medina served as Special
-    Assistant to the Secretary of Defense. Previously, Ms. Medina served as the Principal
-    Deputy Undersecretary of Commerce for Oceans and Atmosphere at the National Oceanic
-    and Atmospheric Administration, where she led efforts on Arctic conservation and
-    restoration of the Gulf of Mexico after the Deepwater Horizon oil spill.  She
-    also currently serves on the boards of directors of two non-profit organizations:
-    SkyTruth, Inc., which uses satellite imagery to monitor environmental threats;
-    and the Service Women’s Action Network, that supports women service members and
-    veterans.'
+  headshot: https://res.cloudinary.com/csisideaslab/image/upload/v1546548140/ocean/Monica_Medina-1.jpg
+  bio: '[**Monica Medina**](https://www.csis.org/people/monica-medina) is the founder and publisher of Our Daily Planet, an environmental e-mail newsletter, and an independent consultant. She is also an adjunct professor in the School of Foreign Service at Georgetown University. Previously, Ms. Medina served as deputy director of the Environment Program at the Walton Family Foundation, and she was senior director of ocean policy at the National Geographic Society. From 2012 to 2013, she served as special assistant to the secretary of defense. Earlier, she served as principal deputy undersecretary of commerce for oceans and atmosphere at the National Oceanic and Atmospheric Administration, where she led efforts on Arctic conservation and restoration of the Gulf of Mexico after the Deepwater Horizon oil spill.'
 mission_statement: |-
-  * The Stephenson Ocean Security Project will examine the links between ocean health and global security while proposing policy solutions that support sustainable development and reduce conflict.
-  * The project will focus on the ways in which ecological and socioeconomic changes interact to drive competition for marine resources and how this competition contributes to instability and geopolitical risk.  Proposed solutions will emphasize the ways in which effective ocean governance can moderate this risk and increase the resilience of both ecosystems and states to destabilizing forces of change.
-
+  The Stephenson Ocean Security (SOS) Project examines the intersection of ocean health and global security. It proposes policy solutions that support sustainable development and reduce conflict.
+  ***
+  This project focuses on the ways ecological and socioeconomic changes interact to drive competition for marine resources and how such competition contributes to instability and geopolitical risk. Proposed policy solutions emphasize the ways effective ocean governance can moderate these risks and increase the resilience of both ecosystems and states against the destabilizing forces of change.
 ---
 The competition for ocean resources is increasing rapidly as coastal nations expand their economies and the global population continues its growth towards eleven billion people by the end of the century.  More than three billion people already depend on fish for a critical portion of their daily protein intake and this number is expected to grow in the years to come, even as 90 percent of global fish stocks are already fished at or above sustainable levels.  This crush of supply and demand is a growing cause of instability in key regions of the globe including the western Pacific, the Gulf of Guinea, and the Arctic.  Conflicts in these regions have the potential to arise from and be exacerbated by resource competition.
 
@@ -54,7 +41,7 @@ Compounding these disruptive forces is the continuing shift in marine ecosystems
 
 In addition to fisheries conflicts, ongoing debates about access to oil and gas resources on the Arctic outer continental shelf and in disputed waters in the South China Sea have the potential to exacerbate existing political tensions.  On the high seas, the developing debate over management of sea bed mining and conserving biodiversity beyond national jurisdiction (BBNJ) will serve as practical demonstrations of the ability of the UN Convention on the Law of the Sea and its subsidiary agreements to serve as effective modes of ocean governance.
 
-The Stephenson Ocean Security Project is a new initiative of the [Center for Strategic and International Studies](https://csis.org) that aims to highlight these challenges and promote solutions that support sustainable development, coalition building, and the need for American leadership.
+The Stephenson Ocean Security Project is a new initiative of the [Center for Strategic and International Studies](https://www.csis.org) that aims to highlight these challenges and promote solutions that support sustainable development, coalition building, and the need for American leadership.
 
 ### Key Issues
 

--- a/assets/_sass/pages/_about.scss
+++ b/assets/_sass/pages/_about.scss
@@ -1,6 +1,9 @@
 .about {
   order: 4;
   margin-top: 2.5rem;
+  @include breakpoint('large') {
+    width: calc(100% - #{$size__post-sidebar-width});
+  }
 
   h2 {
     @extend %post-content__h2;

--- a/assets/_sass/pages/_about.scss
+++ b/assets/_sass/pages/_about.scss
@@ -1,9 +1,16 @@
 .about {
   order: 4;
   margin-top: 2.5rem;
+
   @include breakpoint('large') {
     width: calc(100% - #{$size__post-sidebar-width});
   }
+
+  @include structure(
+    $size__post-body-padding-right,
+    'padding-right',
+    ('large', 'xlarge')
+  );
 
   h2 {
     @extend %post-content__h2;
@@ -15,6 +22,8 @@
 
   &-person {
     margin: 1rem 0 2rem;
+    @extend %body-text__med;
+    text-align: left;
 
     @include breakpoint($break: 'medium', $dir: 'max-width') {
       text-align: center;
@@ -29,8 +38,8 @@
 
     img {
       width: 100%;
-      max-width: 224px;
-      margin-bottom: 1rem;
+      max-width: 150px;
+      margin: 0.5rem 0 1rem;
     }
   }
 
@@ -47,10 +56,5 @@
     margin-bottom: 0.5rem;
     color: $color__black;
     text-transform: uppercase;
-  }
-
-  &-bio {
-    @extend %body-text__med;
-    text-align: left;
   }
 }


### PR DESCRIPTION
I'm PR'ing this, even though there are edits to make in the opening paragraph, so that it can be looked at as needed before the last edits.

- Deleted 'Mission Statement' and 'About' titles and styled the former accordingly. Page break is done through a 'replace' filter, which might not be the cleanest.
- Fixed csis.org link
- Updated Monica's title + bio accordingly.
- Added markdown links to bios for Monica, Whit, Jacque & Tucker and edited Creative and Development team as specified.
- Added necessary filters for margin-right and width, so that it's the same as the post content. Did not add the `post__content` or `post-content` classes instead because they have slightly different styles for headers, other margins, styles etc.
- Removed `author-bio` class and made those the default text styles for the parent div. This way, I could render the markdown of the author bio w/ their respective links.