### PR TITLE
Fix/scs footer

### DIFF
--- a/assets/_js/spotlights/scs/intro.js
+++ b/assets/_js/spotlights/scs/intro.js
@@ -40,9 +40,6 @@ const Intro = () => {
     triggerHook: 'onEnter'
   })
     .setClassToggle('.scs__intro-map', 'is-last')
-    .on('enter', function() {
-      console.log('enter')
-    })
     .addTo(controller)
 
   new ScrollMagic.Scene({

--- a/assets/_js/spotlights/scs/map.js
+++ b/assets/_js/spotlights/scs/map.js
@@ -3,7 +3,6 @@ import ScrollMagic from 'ScrollMagic'
 
 const Map = () => {
   const graphicEl = document.querySelector('.scs__map')
-  const contentEl = document.querySelector('.spotlight__content')
   const triggerEls = Array.from(graphicEl.querySelectorAll('.scs__map-trigger'))
 
   // init controller

--- a/assets/_sass/abstracts/_variables.scss
+++ b/assets/_sass/abstracts/_variables.scss
@@ -96,7 +96,8 @@ $breakpoints: (
   // 900px
     'large-2': 68.75em,
   // 1050px
-    'xlarge': 80em// 1280px
+    'xlarge': 80em, // 1280px
+    'xlarge-2': 90em // 1440px
 );
 
 // prettier-ignore

--- a/assets/_sass/pages/_spotlight.scss
+++ b/assets/_sass/pages/_spotlight.scss
@@ -27,5 +27,11 @@
     padding: 3rem 0;
     background-color: $color__ltgray-lighter;
     @include full-width-background($color__ltgray-lighter);
+
+    @include breakpoint('large') {
+      width: $size__spotlight-body-width;
+      margin-right: auto;
+      margin-left: auto;
+    }
   }
 }

--- a/assets/_sass/spotlights/components/_footer.scss
+++ b/assets/_sass/spotlights/components/_footer.scss
@@ -1,10 +1,4 @@
 .spotlight__footer {
-  @include breakpoint('medium') {
-    width: 500px;
-    margin-right: auto;
-    margin-left: auto;
-  }
-
   > *:not(:last-of-type) {
     margin-bottom: 3rem;
   }

--- a/assets/_sass/spotlights/scs/_intro.scss
+++ b/assets/_sass/spotlights/scs/_intro.scss
@@ -112,6 +112,10 @@
         height: 100vh;
       }
 
+      @include breakpoint('xlarge-2') {
+        width: auto;
+      }
+
       .st1 {fill: none;}
       .st2 {fill: #2b394f;}
       .st3 {fill: #1f2d3a;}
@@ -161,6 +165,7 @@
 
     @include breakpoint('medium') {
       width: 50%;
+      max-width: 700px;
     }
 
     .post-title {

--- a/assets/_sass/spotlights/scs/_map.scss
+++ b/assets/_sass/spotlights/scs/_map.scss
@@ -42,6 +42,7 @@
 
     @include breakpoint('medium') {
       width: 33%;
+      max-width: 700px;
       padding: 1px 0;
     }
 
@@ -65,6 +66,12 @@
 
     @include breakpoint('medium') {
       height: 100%;
+    }
+
+    @include breakpoint('xlarge-2') {
+      position: relative;
+      left: 0;
+      width: auto;
     }
 
     .key {


### PR DESCRIPTION
- Cleans up some of the SCS JS, removing console logs & unnecessary variables
- Makes the footer of the spotlights the same width as the content
- Adds an `xlarge-2` breakpoint at 1440px. Screens larger than this will shift the SVGs over to the far left of the screen.