### PR TITLE
Fix/linkedin

### DIFF
--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -12,7 +12,7 @@
     <a href="https://twitter.com/intent/tweet?text={{ page.title | escape }}&url={{ shareLink }}&via=CSIS&related=CSIS" rel="nofollow" target="_blank" title="Share on Twitter"><i class="icon icon-twitter"></i></a>
   </li>
   <li>
-    <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ shareLink }}&summary={{ page.title | escape }}" rel="nofollow" target="_blank" title="Share on LinkedIn"><i class="icon icon-linkedin"></i></a>
+    <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ shareLink }}&summary={{ page.title | escape }}&source=CSIS" rel="nofollow" target="_blank" title="Share on LinkedIn"><i class="icon icon-linkedin"></i></a>
   </li>
   <li>
     <a href="mailto:?subject={{ site.title | escape }}: {{ page.title | escape }}&amp;body={{ shareLink }}"><i class="icon icon-email"></i></a>

--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -12,7 +12,7 @@
     <a href="https://twitter.com/intent/tweet?text={{ page.title | escape }}&url={{ shareLink }}&via=CSIS&related=CSIS" rel="nofollow" target="_blank" title="Share on Twitter"><i class="icon icon-twitter"></i></a>
   </li>
   <li>
-    <a href="{{ site.data.language.meta.linkedin }}{{ include.shareLink | absolute_url }}" rel="nofollow" target="_blank" title="Share on LinkedIn"><i class="icon icon-linkedin"></i></a>
+    <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ shareLink }}" rel="nofollow" target="_blank" title="Share on LinkedIn"><i class="icon icon-linkedin"></i></a>
   </li>
   <li>
     <a href="mailto:?subject={{ site.title | escape }}: {{ page.title | escape }}&amp;body={{ shareLink }}"><i class="icon icon-email"></i></a>

--- a/_includes/social-share.html
+++ b/_includes/social-share.html
@@ -12,7 +12,7 @@
     <a href="https://twitter.com/intent/tweet?text={{ page.title | escape }}&url={{ shareLink }}&via=CSIS&related=CSIS" rel="nofollow" target="_blank" title="Share on Twitter"><i class="icon icon-twitter"></i></a>
   </li>
   <li>
-    <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ shareLink }}" rel="nofollow" target="_blank" title="Share on LinkedIn"><i class="icon icon-linkedin"></i></a>
+    <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ shareLink }}&summary={{ page.title | escape }}" rel="nofollow" target="_blank" title="Share on LinkedIn"><i class="icon icon-linkedin"></i></a>
   </li>
   <li>
     <a href="mailto:?subject={{ site.title | escape }}: {{ page.title | escape }}&amp;body={{ shareLink }}"><i class="icon icon-email"></i></a>


### PR DESCRIPTION
It should share now on Linkedin, though there's not a photo or preview link yet like because there's no oceans url. When that's added, the button should share the page like the sample below. Right now, it's just a blank screen.
![screen shot 2019-01-04 at 10 34 00 am](https://user-images.githubusercontent.com/18509789/50696001-4aacc780-100c-11e9-8839-03e0f4c0f63d.png)
