### PR TITLE
Fix/timeline n babel

### DIFF
--- a/assets/_js/archives.js
+++ b/assets/_js/archives.js
@@ -1,3 +1,5 @@
+import '@babel/polyfill'
+
 import ArchiveCutout from './archive-cutout'
 import AlgoliaSearch from './algolia-search'
 

--- a/assets/_js/bundle.js
+++ b/assets/_js/bundle.js
@@ -1,3 +1,5 @@
+import '@babel/polyfill'
+
 import FooterBgHeight from './footer-bg-height'
 import Header from './header'
 import HeaderSearch from './header-search'

--- a/assets/_js/home.js
+++ b/assets/_js/home.js
@@ -1,3 +1,5 @@
+import '@babel/polyfill'
+
 import * as PIXI from 'pixi.js'
 import TweenMax from 'TweenMax'
 import TimelineMax from 'TimelineMax'

--- a/assets/_js/spotlights.js
+++ b/assets/_js/spotlights.js
@@ -1,3 +1,5 @@
+import '@babel/polyfill'
+
 import Explainer from './spotlights/explainer'
 import HeaderShare from './spotlights/header-share'
 import ProgressBar from './spotlights/progress-bar'

--- a/assets/_js/spotlights/arctic/arctic.js
+++ b/assets/_js/spotlights/arctic/arctic.js
@@ -1,2 +1,4 @@
+import '@babel/polyfill'
+
 console.log('Test Spotlights JS')
 console.log('arctic test')

--- a/assets/_js/spotlights/scs/scs.js
+++ b/assets/_js/spotlights/scs/scs.js
@@ -1,3 +1,5 @@
+import '@babel/polyfill'
+
 import chartVessels from './chartVessels'
 import chartCatch from './chartCatch'
 import Intro from './intro'

--- a/gulp_tasks/webpack.js
+++ b/gulp_tasks/webpack.js
@@ -1,33 +1,57 @@
-const argv          = require('yargs').argv;
-const babel         = require('gulp-babel');
-const config        = require('../frasco.config.js')
-const gulp          = require('gulp');
-const named         = require('vinyl-named');
-const plumber       = require('gulp-plumber');
-const webpackStream = require('webpack-stream');
-const webpack       = require('webpack');
+const argv = require('yargs').argv
+const babel = require('gulp-babel')
+const config = require('../frasco.config.js')
+const gulp = require('gulp')
+const named = require('vinyl-named')
+const plumber = require('gulp-plumber')
+const webpackStream = require('webpack-stream')
+const webpack = require('webpack')
 
-const entry = [];
+const entry = []
 for (var i = 0; i <= config.js.entry.length - 1; i++) {
-  entry.push(config.assets + '/' + config.js.src + '/' + config.js.entry[i]);
+  entry.push(config.assets + '/' + config.js.src + '/' + config.js.entry[i])
 }
 
-if (config.tasks.eslint) config.webpack.module.rules.push(config.eslintLoader);
+if (config.tasks.eslint) config.webpack.module.rules.push(config.eslintLoader)
 
-config.webpack.watch = argv.watch;
-config.webpack.mode = argv.mode || config.webpack.mode;
+config.webpack.watch = argv.watch
+config.webpack.mode = argv.mode || config.webpack.mode
 
-gulp.task('webpack', function () {
-  return gulp.src(entry)
+gulp.task('webpack', function() {
+  return gulp
+    .src(entry)
     .pipe(plumber())
     .pipe(named())
-    .pipe(babel())
+    .pipe(
+      babel({
+        plugins: ['@babel/plugin-transform-runtime'],
+        presets: [
+          [
+            '@babel/preset-env',
+            {
+              useBuiltIns: 'entry',
+              debug: true,
+              targets: {
+                android: '4.2',
+                chrome: '41',
+                edge: '17',
+                firefox: '52',
+                ie: '11',
+                ios: '9.3',
+                opera: '56',
+                safari: '10.1'
+              }
+            }
+          ]
+        ]
+      })
+    )
     .pipe(webpackStream(config.webpack, webpack))
-    .pipe(gulp.dest(config.assets + '/' + config.js.dest));
-});
+    .pipe(gulp.dest(config.assets + '/' + config.js.dest))
+})
 
 // For internal use only
-gulp.task('_webpack', function () {
-  config.webpack.watch = config.tasks.watch;
-  gulp.start('webpack');
-});
+gulp.task('_webpack', function() {
+  config.webpack.watch = config.tasks.watch
+  gulp.start('webpack')
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -567,6 +567,18 @@
         "regenerator-transform": "^0.13.3"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz",
+      "integrity": "sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
@@ -625,6 +637,15 @@
         "regexpu-core": "^4.1.3"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
+      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+      "requires": {
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.12.0"
+      }
+    },
     "@babel/preset-env": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.0.tgz",
@@ -672,6 +693,14 @@
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.3.0"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
       }
     },
     "@babel/template": {
@@ -12627,6 +12656,11 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regenerator-transform": {
       "version": "0.13.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.1.2",
+    "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.1.0",
     "autoprefixer": "^9.4.3",
     "browser-sync": "^2.26.3",
@@ -68,6 +69,8 @@
     "yargs": "^12.0.2"
   },
   "dependencies": {
+    "@babel/polyfill": "^7.2.5",
+    "@babel/runtime": "^7.2.0",
     "@threespot/freeze-scroll": "^1.0.3",
     "algoliasearch": "^3.30.0",
     "algoliasearch-helper": "^2.26.1",


### PR DESCRIPTION
Using a simple for loop instead of using an array as a counter fixed this issue on mobile for me. 

I'll keep this ngrok link up for testing on android: https://3f4045b7.ngrok.io/spotlights/illuminating-the-south-china-seas-dark-fishing-fleets/

Spin this up and you will see console.logs via the debug: true option. You can see what plugins are available and where they are applied

```
[/Users/leeza/Sites/ocean/assets/_js/home.js] Replaced `@babel/polyfill` with the following
polyfills:
  es6.array.copy-within { "android":"4.2", "chrome":"41", "ie":"11" }
  es6.array.fill { "android":"4.2", "chrome":"41", "ie":"11" }
  es6.array.find { "android":"4.2", "chrome":"41", "ie":"11" }
  es6.array.find-index { "android":"4.2", "chrome":"41", "ie":"11" }
  es6.array.from { "android":"4.2", "chrome":"41", "ie":"11", "ios":"9.3" }
  es7.array.includes { "android":"4.2", "chrome":"41", "ie":"11", "ios":"9.3"}
```


### 3 options for polyfilling:

- If useBuiltIns: 'usage' is specified in .babelrc then do not include @babel/polyfill in either 

> webpack.config.js entry array nor source. Note, @babel/polyfill still needs to be installed.
> - If useBuiltIns: 'entry' is specified in .babelrc then include @babel/polyfill at the top of the entry point to your application via require or import as discussed above.
> -  If useBuiltIns key is not specified or it is explicitly set with useBuiltIns: false in your .babelrc, add @babel/polyfill directly to the entry array in your webpack.config.js.

(babeljs.io/docs/en/babel-polyfill#usage-in-node-browserify-webpack)


"Usage" did nothing (ex: "[/Users/leeza/Sites/ocean/assets/_js/spotlights.js] Based on your code and targets, none were added." Could not get the last option, "false," to work.

### This is not ready to be merged though. The same console log errors show up in IE. It seems not to be working! Complained about Object.find. I see spread operators, let, and var in the code in IE. 

### Only Timeline file is working