### PR TITLE
Add autoprefixer for CSS grid

### DIFF
--- a/assets/_sass/components/_post-block.scss
+++ b/assets/_sass/components/_post-block.scss
@@ -25,14 +25,19 @@
       position: relative;
       z-index: 2;
       display: grid;
+      grid-template-areas:
+        'img header'
+        'img content'
+        'img footer';
       grid-template-columns: repeat(2, auto);
+      grid-template-rows: 1;
 
-      &:first-of-type {
-        grid-template-areas:
-          'img header'
-          'img content'
-          'img footer';
-      }
+      // &:first-of-type {
+      //   grid-template-areas:
+      //     'img header'
+      //     'img content'
+      //     'img footer';
+      // }
 
       &:last-of-type {
         grid-template-areas:
@@ -52,28 +57,74 @@
     $body-width: minmax(auto, $size__post-body-max-width);
     display: grid;
     grid-column-gap: 1.5rem;
-    grid-template-areas:
-      'header img'
-      'content img';
+    // grid-template-areas:
+    //   'header img'
+    //   'content img';
     grid-template-columns: $body-width 80px;
-    grid-template-rows: auto auto;
+    grid-template-rows: repeat(2, auto);
     padding-right: 0;
 
     @include breakpoint('medium') {
       grid-column-gap: 2rem;
       grid-template-columns: $body-width 190px;
+      grid-template-rows: repeat(2, auto);
       max-height: min-content;
       padding-right: 0;
     }
 
     @include breakpoint('large') {
       grid-template-columns: $body-width 30%;
+      grid-template-rows: repeat(2, auto);
       max-width: 100%;
       padding-right: 0;
     }
 
     @include breakpoint('xlarge') {
       grid-template-columns: $body-width 270px;
+      grid-template-rows: repeat(2, auto);
+    }
+
+    &.post-block--featured {
+      @include breakpoint($break: 'medium', $dir: 'max-width') {
+        grid-template-columns: 1fr;
+        grid-template-rows: repeat(3, auto);
+      }
+
+      .post-block__img {
+        @include breakpoint($break: 'medium', $dir: 'max-width') {
+          grid-column: 1;
+          grid-row: 2;
+        }
+      }
+
+      .post-block__content {
+        @include breakpoint($break: 'medium', $dir: 'max-width') {
+          grid-column: 1;
+          grid-row: 3;
+        }
+      }
+    }
+
+    .post-block__header {
+      grid-column: 1;
+      grid-row: 1;
+    }
+
+    .post-block__img {
+      grid-column: 2;
+      grid-row: 1 / 3;
+    }
+
+    .post-block__content {
+      grid-column: 1;
+      grid-row: 2 / 3;
+
+      .post-block--featured & {
+        @include breakpoint($break: 'medium', $dir: 'max-width') {
+          grid-column: 1;
+          grid-row: 3;
+        }
+      }
     }
   }
 
@@ -148,6 +199,8 @@
   }
 
   &__footer {
+    grid-area: footer;
+
     .layout-home & {
       padding-bottom: 0.25rem;
 
@@ -213,14 +266,6 @@
 
   .archive &--featured {
     margin-bottom: 2rem;
-
-    @include breakpoint($break: 'medium', $dir: 'max-width') {
-      grid-template-areas:
-        'header'
-        'img'
-        'content';
-      grid-template-columns: auto;
-    }
 
     #{$post}__header {
       padding-top: 1rem;

--- a/assets/_sass/components/_related-posts.scss
+++ b/assets/_sass/components/_related-posts.scss
@@ -7,9 +7,9 @@
   grid-row-gap: 0.5rem;
 
   @include breakpoint('medium') {
-    display: grid;
     grid-column-gap: 4rem;
     grid-template-columns: auto auto;
+    grid-template-rows: 1;
   }
 
   &__header {

--- a/assets/_sass/pages/_home.scss
+++ b/assets/_sass/pages/_home.scss
@@ -271,7 +271,7 @@
     @include breakpoint('large') {
       display: grid;
       grid-column-gap: 4rem;
-      grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+      grid-template-columns: repeat(2, 1fr);
       grid-template-rows: repeat(2, auto);
       max-width: 950px;
       margin-right: auto;

--- a/frasco.config.js
+++ b/frasco.config.js
@@ -72,7 +72,7 @@ module.exports = {
     dest: 'css',
     outputStyle: 'compressed',
     autoprefixer: {
-      // grid: true,
+      grid: "autoplace",
       browsers: ['> 1%', 'last 2 versions', 'Firefox ESR']
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1361,34 +1361,34 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.3.tgz",
-      "integrity": "sha512-/XSnzDepRkAU//xLcXA/lUWxpsBuw0WiriAHOqnxkuCtzLhaz+fL4it4gp20BQ8n5SyLzK/FOc7A0+u/rti2FQ==",
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.4.tgz",
+      "integrity": "sha512-7tpjBadJyHKf+gOJEmKhZIksWxdZCSrnKbbTJNsw+/zX9+f//DLELRQPWjjjVoDbbWlCuNRkN7RfmZwDVgWMLw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.3.6",
-        "caniuse-lite": "^1.0.30000921",
+        "browserslist": "^4.3.7",
+        "caniuse-lite": "^1.0.30000926",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.6",
+        "postcss": "^7.0.7",
         "postcss-value-parser": "^3.3.1"
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.6.tgz",
-          "integrity": "sha512-kMGKs4BTzRWviZ8yru18xBpx+CyHG9eqgRbj9XbE3IMgtczf4aiA0Y1YCpVdvUieKGZ03kolSPXqTcscBCb9qw==",
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.7.tgz",
+          "integrity": "sha512-pWQv51Ynb0MNk9JGMCZ8VkM785/4MQNXiFYtPqI7EEP0TJO+/d/NqRVn1uiAN0DNbnlUSpL2sh16Kspasv3pUQ==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000921",
-            "electron-to-chromium": "^1.3.92",
-            "node-releases": "^1.1.1"
+            "caniuse-lite": "^1.0.30000925",
+            "electron-to-chromium": "^1.3.96",
+            "node-releases": "^1.1.3"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30000923",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000923.tgz",
-          "integrity": "sha512-j5ur7eeluOFjjPUkydtXP4KFAsmH3XaQNch5tvWSO+dLHYt5PE+VgJZLWtbVOodfWij6m6zas28T4gB/cLYq1w==",
+          "version": "1.0.30000927",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000927.tgz",
+          "integrity": "sha512-ogq4NbUWf1uG/j66k0AmiO3GjqJAlQyF8n4w8a954cbCyFKmYGvRtgz6qkq2fWuduTXHibX7GyYL5Pg58Aks2g==",
           "dev": true
         },
         "electron-to-chromium": {
@@ -1398,9 +1398,9 @@
           "dev": true
         },
         "node-releases": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.2.tgz",
-          "integrity": "sha512-j1gEV/zX821yxdWp/1vBMN0pSUjuH9oGUdLCb4PfUko6ZW7KdRs3Z+QGGwDUhYtSpQvdVVyLd2V0YvLsmdg5jQ==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.3.tgz",
+          "integrity": "sha512-6VrvH7z6jqqNFY200kdB6HdzkgM96Oaj9v3dqGfgp6mF+cHmU4wyQKZ2/WPDRVoR0Jz9KqbamaBN0ZhdUaysUQ==",
           "dev": true,
           "requires": {
             "semver": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@babel/core": "^7.1.2",
     "@babel/preset-env": "^7.1.0",
-    "autoprefixer": "^9.4.3",
+    "autoprefixer": "^9.4.4",
     "browser-sync": "^2.26.3",
     "css-mqpacker": "^7.0.0",
     "cssnano": "^4.1.7",


### PR DESCRIPTION
The autoprefixer error that I was getting before was a consequence of how the grid was set up in the post-block include. I modified it and now the prefixes are working as expected.

Note: Once we have more than 2 commentaries, we'll need to update the home page so it can accommodate 3 commentaries. This was the easiest solution than fighting to get IE to like the auto-fit solution.

I've left the comments in that indicate the problem areas. I'd like to go back and figure out exactly why those weren't working at some point in the future.