### PR TITLE
Fix/highchart catch again

### DIFF
--- a/assets/_js/spotlights/scs/chartCatch.js
+++ b/assets/_js/spotlights/scs/chartCatch.js
@@ -20,7 +20,7 @@ const chartCatch = () => {
     subtitle: {
       align: 'left',
       text:
-        "The Spratly Island values represent 12% of the entire South China Sea estimated fishing capacity, estimated to range between 10 and 20 million tons."
+        "The Spratly Island values represent 12% of the fishing capacity of the entire South China Sea, which is estimated to range between 10 and 20 million tons."
     },
     credits: {
       enabled: true,

--- a/assets/_js/spotlights/scs/chartCatch.js
+++ b/assets/_js/spotlights/scs/chartCatch.js
@@ -20,7 +20,7 @@ const chartCatch = () => {
     subtitle: {
       align: 'left',
       text:
-        "The Spratly Islands' values represent 12% of the South China Sea entire fishing capacity, which is estimated to range between 10 and 20 million tons."
+        "The Spratly Island values represent 12% of the entire South China Sea estimated fishing capacity, estimated to range between 10 and 20 million tons."
     },
     credits: {
       enabled: true,

--- a/assets/_js/spotlights/scs/chartCatch.js
+++ b/assets/_js/spotlights/scs/chartCatch.js
@@ -20,7 +20,7 @@ const chartCatch = () => {
     subtitle: {
       align: 'left',
       text:
-        "The Spratly Island values represent 12% of the fishing capacity of the entire South China Sea, which is estimated to range between 10 and 20 million tons."
+        "The Spratly Islands' values represent 12% of the fishing capacity of the entire South China Sea, which is estimated to range between 10 and 20 million tons."
     },
     credits: {
       enabled: true,

--- a/assets/_js/spotlights/scs/chartCatch.js
+++ b/assets/_js/spotlights/scs/chartCatch.js
@@ -20,7 +20,7 @@ const chartCatch = () => {
     subtitle: {
       align: 'left',
       text:
-        'The Spratly Island values represent 12% of the entire South China Sea estimated catch of 10 million (low) or 20 million (high) tons.'
+        "The Spratly Islands' values represent 12% of the South China Sea entire fishing capacity, which is estimated to range between 10 and 20 million tons."
     },
     credits: {
       enabled: true,


### PR DESCRIPTION
Original: The Spratly Island values represent 12% of the entire South China Sea estimated catch of 10 million (low) or 20 million (high) tons.
Edited: The Spratly Island values represent 12% of the fishing capacity of the entire South China Sea, which is estimated to range between 10 and 20 million tons.

Figured this isn't important, so I'm not slacking it: grammatically, I think it's supposed to be " Spratly Islands' ", but I didn't change the wording for that, as I might be wrong. Wasn't sure if that was an editorial decision.