### PR TITLE
Feature/lazy loading

### DIFF
--- a/_includes/cloudinary-responsive-img.html
+++ b/_includes/cloudinary-responsive-img.html
@@ -1,5 +1,8 @@
 {%- if include.path.size > 0 -%}
 <figure class="{{ include.classes | default: post__image }}">
+{%- if include.mobile_path.size > 0 -%}
+  <picture>
+{%- endif -%}
 
 {%- assign height=null -%}
 {%- if include.height.size > 0 -%}
@@ -17,21 +20,28 @@
 
   {%- if include.mobile_path.size > 0 -%}
     {%- assign sm_image_name = include.mobile_path | split: "/upload/" | last -%}
+    <!--[if IE 9]><video style="display: none;><![endif]-->
+    <source
+      data-srcset="{{ site.cloudinary_url }}f_auto,q_auto,w_600/{{  sm_image_name }}"
+      media="(max-width: 900px)" />
+    <source
+      data-srcset="{{ site.cloudinary_url }}f_auto,q_auto,w_auto/{{  lg_image_name }}" />
+    <!--[if IE 9]></video><![endif]-->
+    <img 
+    data-src="{{ site.cloudinary_url }}f_auto,q_auto,w_600/{{  sm_image_name }}" class="lazyload" 
+    alt="{{ include.title | strip_html }}" style="{{ height }}" />
+  </picture>
   {%- else -%}
-      {%- assign sm_image_name = lg_image_name -%}
+    <img
+    data-sizes="auto" 
+    src="{{ site.cloudinary_url }}f_auto,q_10,w_auto,e_blur:1000/{{ lg_image_name }}" 
+    data-srcset="{{ site.cloudinary_url }}f_auto,q_auto,w_300/{{  lg_image_name }} 300w,
+    {{ site.cloudinary_url }}f_auto,q_auto,w_600/{{  lg_image_name }} 600w,
+      {{ site.cloudinary_url }}f_auto,q_auto,w_900/{{ lg_image_name }} 900w"
+    class="lazyload"
+    alt="{{ include.title | strip_html }}"
+    style="{{ height }}" />
   {%- endif -%}
-
-  <img
-  sizes="(max-width: 300px) 300px,
-      (max-width: 500px) 500px,
-      (max-width: 700px) 700px,
-      (max-width: 100%) 1360px"
-  srcset="{{ site.cloudinary_url }}f_auto,q_70,w_300/{{  sm_image_name }} 300w,
-          {{ site.cloudinary_url }}f_auto,q_70,w_500/{{  sm_image_name }} 500w,
-          {{ site.cloudinary_url }}f_auto,q_70,w_700/{{  sm_image_name }} 700w,
-          {{ site.cloudinary_url }}f_auto,q_70,w_1360/{{ lg_image_name }} 1360w"
-  src="{{ site.cloudinary_url }}f_auto,q_70,w_700/{{  sm_image_name }}" title="{{ include.title  | strip_html }}"
-  alt="{{ include.title | strip_html }}" style="{{ height }}" />
 {%- else -%}
   <img src="{{ include.path }}" title="{{ include.title | strip_html  }}" alt="{{ include.title | strip_html  }}" />
 {%- endif -%}

--- a/_includes/cloudinary-responsive-img.html
+++ b/_includes/cloudinary-responsive-img.html
@@ -1,7 +1,7 @@
 {%- if include.path.size > 0 -%}
 <figure class="{{ include.classes | default: post__image }}">
 {%- if include.mobile_path.size > 0 -%}
-  <picture>
+  <picture class="sc-image-picture">
 {%- endif -%}
 
 {%- assign height=null -%}
@@ -28,16 +28,17 @@
       data-srcset="{{ site.cloudinary_url }}f_auto,q_auto,w_auto/{{  lg_image_name }}" />
     <!--[if IE 9]></video><![endif]-->
     <img 
-    data-src="{{ site.cloudinary_url }}f_auto,q_auto,w_600/{{  sm_image_name }}" class="lazyload" 
+    data-src="{{ site.cloudinary_url }}f_auto,q_auto,w_auto/{{  lg_image_name }}" class="lazyload" 
     alt="{{ include.title | strip_html }}" style="{{ height }}" />
   </picture>
   {%- else -%}
     <img
     data-sizes="auto" 
-    src="{{ site.cloudinary_url }}f_auto,q_10,w_auto,e_blur:1000/{{ lg_image_name }}" 
+    src="{{ site.cloudinary_url }}f_auto,q_10,w_auto,e_blur:1000/{{ lg_image_name }}"
+    data-src="{{ site.cloudinary_url }}f_auto,q_auto,w_auto/{{ lg_image_name }}" 
     data-srcset="{{ site.cloudinary_url }}f_auto,q_auto,w_300/{{  lg_image_name }} 300w,
     {{ site.cloudinary_url }}f_auto,q_auto,w_600/{{  lg_image_name }} 600w,
-      {{ site.cloudinary_url }}f_auto,q_auto,w_900/{{ lg_image_name }} 900w"
+      {{ site.cloudinary_url }}f_auto,q_auto,w_auto/{{ lg_image_name }} 900w"
     class="lazyload"
     alt="{{ include.title | strip_html }}"
     style="{{ height }}" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
+  <script src="{{ "/assets/js/lazy-load.js" | relative_url }}" type="text/javascript" async=""></script>
   <link rel="stylesheet" href="https://use.typekit.net/vho0gap.css">
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}">
   {%- if page.layout == 'home' -%}

--- a/_includes/post-block-home.html
+++ b/_includes/post-block-home.html
@@ -7,8 +7,11 @@
   <a href="{{ post.url | relative_url }}" class="post-block__img">
     <img
       src="{{ post.image | relative_url }}"
+      srcset="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+      data-srcset="{{ post.image | relative_url }}"
       alt="{{ post.title | escape }}"
       title="{{ post.title | escape }}"
+      class="lazyload"
     />
   </a>
   {% endif %}

--- a/_includes/sc-footer.html
+++ b/_includes/sc-footer.html
@@ -24,7 +24,7 @@
       {%- assign author_info = site.authors | where: "relative_path", author | first -%}
         <div class="authors-block">
           {%- if author_info.headshot.size > 0 -%}
-            <img class="authors-block__photo" src="{{ author_info.headshot }}" />
+            <img class="authors-block__photo lazyload" data-src="{{ author_info.headshot }}" alt="" />
           {%- endif -%}
           <div class="authors-block__bio spotlight__footer-text">
             {{ author_info.content }}

--- a/_includes/sc-tooltip-video.html
+++ b/_includes/sc-tooltip-video.html
@@ -20,7 +20,7 @@
         <span class="sc-tooltip-video__content__text-name">{{ include.name }}</span>
         <span class="sc-tooltip-video__content__text-duration">({{ include.duration }} min)</span>
       </div>
-      <img class="sc-tooltip-video__content-thumbnail" src="{{ include.thumbnail }}"/>
+      <img class="sc-tooltip-video__content-thumbnail lazyload" data-src="{{ include.thumbnail }}" alt="" />
     </div>
 </div>
 {%- endif -%}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -22,7 +22,7 @@ layout: default
 
           <h3 class="about-heading">{{ person.name }}</h3>
           <div class="about-subheading">{{ person.title }}</div>
-          <img src="{{ person.headshot | relative_url }}" alt="{{ person.name | escape }}" title="{{ person.name | escape }}" />
+          <img data-src="{{ person.headshot | relative_url }}" alt="{{ person.name | escape }}" title="{{ person.name | escape }}" class="lazyload" />
           {{ person.bio | markdownify }}
 
         </div>

--- a/_spotlights/illuminating-the-south-china-seas-dark-fishing-fleets.md
+++ b/_spotlights/illuminating-the-south-china-seas-dark-fishing-fleets.md
@@ -3,26 +3,27 @@ title: Illuminating the South China Sea’s Dark Fishing Fleets
 date: 2019-01-03 14:00:00 +0000
 prefix: scs
 js_files:
-- https://cdnjs.cloudflare.com/ajax/libs/highcharts/6.2.0/highcharts.js
-- https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js
-- https://code.highcharts.com/modules/data.js
-- https://code.highcharts.com/modules/pattern-fill.js
-- scs
+  - https://cdnjs.cloudflare.com/ajax/libs/highcharts/6.2.0/highcharts.js
+  - https://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js
+  - https://code.highcharts.com/modules/data.js
+  - https://code.highcharts.com/modules/pattern-fill.js
+  - scs
 css_files:
-- scs
+  - scs
 include_header: scs/intro.html
-excerpt: Unseen fishing activity. Maritime militias in the Spratlys. Fishers have
+excerpt:
+  Unseen fishing activity. Maritime militias in the Spratlys. Fishers have
   often been overlooked in the South China Sea disputes. CSIS in cooperation with
   Vulcan, Inc., unveil a worrying narrative about the impact fishers and their fleets
   have in the region.
 authors:
-- _authors/gregory-b-poling.md
+  - _authors/gregory-b-poling.md
 keywords:
-- South China Sea
-- Maritime Militia
-- Maritime Domain Awareness
-- Remote Sensing
-- Fishing
+  - South China Sea
+  - Maritime Militia
+  - Maritime Domain Awareness
+  - Remote Sensing
+  - Fishing
 further_reading: |-
   * [Asia Maritime Transparency Initiative](https://amti.csis.org/)
   * [China’s Third Sea Force, The People’s Armed Forces Maritime Militia: Tethered to the PLA](http://www.andrewerickson.com/wp-content/uploads/2017/03/Naval-War-College_CMSI_China-Maritime-Report_No-1_People%E2%80%99s-Armed-Forces-Maritime-Militia-Tethered-to-the-PLA_Kennedy-Erickson_201703.pdf)
@@ -31,7 +32,8 @@ further_reading: |-
   * [Illegal, Unreported, and Unregulated Fishing as a National Security Threat](https://www.csis.org/analysis/illegal-unreported-and-unregulated-fishing-national-security-threat)
   * [An Accounting of China’s Deployments to the Spratly Islands](https://amti.csis.org/accounting-chinas-deployments-spratly-islands/)
   * [Confirming the Chinese Flotilla Near Thitu Island](https://amti.csis.org/confirming-chinese-flotilla-near-thitu-island/)
-methodology: Vulcan, Inc. undertook the analysis of AIS, VIIRS, SAR, and high-resolution
+methodology:
+  Vulcan, Inc. undertook the analysis of AIS, VIIRS, SAR, and high-resolution
   satellite imagery for this project. AIS was provided by ORBCOMM. At the start of
   the project, CSIS and Vulcan identified several areas of interest in the Spratlys
   and requested that satellite imagery provider MDA collect SAR data for them twice
@@ -41,76 +43,82 @@ methodology: Vulcan, Inc. undertook the analysis of AIS, VIIRS, SAR, and high-re
   of activity. High-resolution imagery of those areas from DigitalGlobe was then analyzed
   to identify vessel details.
 related_content:
-- _posts/2018-11-19-test-post.md
+  - _posts/2018-11-19-test-post.md
 is_featured: true
 image: https://res.cloudinary.com/csisideaslab/image/upload/v1546471516/ocean/Chinese-vessels-Mischief-Reef-6-19-18.jpg
 image_caption: Chinese fishing vessels at Mischief Reef on June 19, 2018.
-image_source: "© DigitalGlobe, Inc. and © Vulcan Technologies LLC."
+image_source: '© DigitalGlobe, Inc. and © Vulcan Technologies LLC.'
 related_spotlight:
--
+  -
 related_commentary:
-- _posts/2018-12-10-making-the-oceans-more-secure.md
-- _posts/2018-12-10-taking-a-bi-partisan-approach-to-combatting-illegal-fishing.md
+  - _posts/2018-12-10-making-the-oceans-more-secure.md
+  - _posts/2018-12-10-taking-a-bi-partisan-approach-to-combatting-illegal-fishing.md
 image_groups:
   reefs:
-  - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546470443/ocean/healthy-reef-taiping.jpg
-    caption: A relatively healthy reef flat around Itu Aba Island, occupied by Taiwan.
-    credit: Taiwan Ministry of Internal Affairs
-  - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546470443/ocean/Overfished-Spratly-Reef-Feb-2016.jpg
-    caption: An overfished reef flat surrounding Thitu Island, occupied by the Philippines.
-    credit: John McManus, February 2016
-  - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546470443/ocean/Destroyed-Spratly-Reef-Feb-2016.jpg
-    caption: A reef flat, approximately 1.5 nautical miles away from Thitu Island,
-      destroyed by Chinese clam harvesters.
-    credit: John McManus, February 2016
+    - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546470443/ocean/healthy-reef-taiping.jpg
+      caption: A relatively healthy reef flat around Itu Aba Island, occupied by Taiwan.
+      credit: Taiwan Ministry of Internal Affairs
+    - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546470443/ocean/Overfished-Spratly-Reef-Feb-2016.jpg
+      caption: An overfished reef flat surrounding Thitu Island, occupied by the Philippines.
+      credit: John McManus, February 2016
+    - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546470443/ocean/Destroyed-Spratly-Reef-Feb-2016.jpg
+      caption:
+        A reef flat, approximately 1.5 nautical miles away from Thitu Island,
+        destroyed by Chinese clam harvesters.
+      credit: John McManus, February 2016
   ships:
-  - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546471940/ocean/chinese-falling-net-vessel-mischief-11-1-18.jpg
-    caption: A Chinese light falling net vessel at Mischief Reef on November 1, 2018.
-    credit: "© DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved"
-  - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546471940/ocean/chinese-trawlers-mischief-6-19-18.jpg
-    caption: Chinese trawlers at Mischief Reef on June 19, 2018.
-    credit: "© DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved"
-  - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546471940/ocean/Vietnamese-blue-boats.jpg
-    caption: "<span class=\"sc-image-gallery__captions-single__text-label\">LEFT:</span> Vietnamese blue boats at Ladd Reef on March 18, 2018. <span class=\"sc-image-gallery__captions-single__text-label\">RIGHT:</span> Blue boats in port at Nha Trang, Vietnam in January 2014."
-    credit: "<span class=\"sc-image-gallery__captions-single__text-label--credit\">LEFT:</span> © DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved <span class=\"sc-image-gallery__captions-single__text-label--credit\">RIGHT:</span> Photo courtesy of gavindeas's Flickr feed. Used under Creative Commons."
-  - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546471940/ocean/Vietnamese-squid-jiggers.jpg
-    caption: "<span class=\"sc-image-gallery__captions-single__text-label\">LEFT:</span> A Vietnamese squid jigger near Southwest Cay on August 15, 2018. <span class=\"sc-image-gallery__captions-single__text-label\">RIGHT:</span> A Vietnamese squid jigger in Quang Nam Province. The vessel was later reportedly sunk by the China Coast Guard in the Paracel Islands in 2016."
-    credit: "<span class=\"sc-image-gallery__captions-single__text-label--credit\">LEFT:</span> © DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved <span class=\"sc-image-gallery__captions-single__text-label--credit\">RIGHT:</span> Photo courtesy of Thanh Nien newspaper."
-  - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546471940/ocean/Filipino-bancas.jpg
-    caption: "<span class=\"sc-image-gallery__captions-single__text-label\">LEFT:</span> Filipino bancas near Scarborough Shoal on March 1, 2017. <span class=\"sc-image-gallery__captions-single__text-label\">RIGHT:</span> A Filipino banca near Infanta, Pangasinan province in June 2016."
-    credit: "<span class=\"sc-image-gallery__captions-single__text-label--credit\">LEFT:</span> © DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved <span class=\"sc-image-gallery__captions-single__text-label--credit\">RIGHT:</span> TED ALJIBE / AFP/Getty Images"
+    - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546471940/ocean/chinese-falling-net-vessel-mischief-11-1-18.jpg
+      caption: A Chinese light falling net vessel at Mischief Reef on November 1, 2018.
+      credit: '© DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved'
+    - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546471940/ocean/chinese-trawlers-mischief-6-19-18.jpg
+      caption: Chinese trawlers at Mischief Reef on June 19, 2018.
+      credit: '© DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved'
+    - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546471940/ocean/Vietnamese-blue-boats.jpg
+      caption: '<span class="sc-image-gallery__captions-single__text-label">LEFT:</span> Vietnamese blue boats at Ladd Reef on March 18, 2018. <span class="sc-image-gallery__captions-single__text-label">RIGHT:</span> Blue boats in port at Nha Trang, Vietnam in January 2014.'
+      credit: '<span class="sc-image-gallery__captions-single__text-label--credit">LEFT:</span> © DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved <span class="sc-image-gallery__captions-single__text-label--credit">RIGHT:</span> Photo courtesy of gavindeas''s Flickr feed. Used under Creative Commons.'
+    - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546471940/ocean/Vietnamese-squid-jiggers.jpg
+      caption: '<span class="sc-image-gallery__captions-single__text-label">LEFT:</span> A Vietnamese squid jigger near Southwest Cay on August 15, 2018. <span class="sc-image-gallery__captions-single__text-label">RIGHT:</span> A Vietnamese squid jigger in Quang Nam Province. The vessel was later reportedly sunk by the China Coast Guard in the Paracel Islands in 2016.'
+      credit: '<span class="sc-image-gallery__captions-single__text-label--credit">LEFT:</span> © DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved <span class="sc-image-gallery__captions-single__text-label--credit">RIGHT:</span> Photo courtesy of Thanh Nien newspaper.'
+    - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546471940/ocean/Filipino-bancas.jpg
+      caption: '<span class="sc-image-gallery__captions-single__text-label">LEFT:</span> Filipino bancas near Scarborough Shoal on March 1, 2017. <span class="sc-image-gallery__captions-single__text-label">RIGHT:</span> A Filipino banca near Infanta, Pangasinan province in June 2016.'
+      credit: '<span class="sc-image-gallery__captions-single__text-label--credit">LEFT:</span> © DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved <span class="sc-image-gallery__captions-single__text-label--credit">RIGHT:</span> TED ALJIBE / AFP/Getty Images'
   yue_tai_yu:
-  - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546472554/ocean/Yue-Tai-Yu-vessels-5-25-18.jpg
-    caption: Yue Tai Yu vessels near Hughes Reef on May 25, 2018.
-    credit: "© DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved"
-    mode: portrait
-  - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546472554/ocean/Yue-Tai-Yu-18_-under-construction-8-26-17.jpg
-    caption: The nine vessels of the Yue Tai Yu fleet under construction at Guangxin
-      Shipbuilding & Heavy Industry Co., Ltd on August 26, 2017.
-    credit: "© DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved"
-    mode: landscape
+    - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546472554/ocean/Yue-Tai-Yu-vessels-5-25-18.jpg
+      caption: Yue Tai Yu vessels near Hughes Reef on May 25, 2018.
+      credit: '© DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved'
+      mode: portrait
+    - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546472554/ocean/Yue-Tai-Yu-18_-under-construction-8-26-17.jpg
+      caption:
+        The nine vessels of the Yue Tai Yu fleet under construction at Guangxin
+        Shipbuilding & Heavy Industry Co., Ltd on August 26, 2017.
+      credit: '© DigitalGlobe, Inc. and © Vulcan Technologies LLC. All Rights Reserved'
+      mode: landscape
   yue_tai_yu_composite:
-  - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546474414/ocean/yuethaiyu_composite_lg%402x-80.jpg
-    mobile_url: https://res.cloudinary.com/csisideaslab/image/upload/v1546474414/ocean/yuethaiyu_composite_sm%402x-80.jpg
-    caption: AIS signals show that the Yue Tai Yu ships sailed from the shipyard to
-      the port of Shadi in December 2017 and then on to the Spratly Islands.
-    credit: CSIS
-  - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546474414/ocean/yuethaiyu_zoom_lg%402x-80.jpg
-    mobile_url: https://res.cloudinary.com/csisideaslab/image/upload/v1546474414/ocean/yuethaiyu_zoom_sm%402x-80.jpg
-    caption: AIS signals show that from January to September 2018, the Yue Tai Yu
-      vessels have operated near Chinese outposts in the Spratlys with no apparent
-      signs of fishing.
-    credit: CSIS
+    - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546474414/ocean/yuethaiyu_composite_lg%402x-80.jpg
+      mobile_url: https://res.cloudinary.com/csisideaslab/image/upload/v1546474414/ocean/yuethaiyu_composite_sm%402x-80.jpg
+      caption:
+        AIS signals show that the Yue Tai Yu ships sailed from the shipyard to
+        the port of Shadi in December 2017 and then on to the Spratly Islands.
+      credit: CSIS
+    - url: https://res.cloudinary.com/csisideaslab/image/upload/v1546474414/ocean/yuethaiyu_zoom_lg%402x-80.jpg
+      mobile_url: https://res.cloudinary.com/csisideaslab/image/upload/v1546474414/ocean/yuethaiyu_zoom_sm%402x-80.jpg
+      caption:
+        AIS signals show that from January to September 2018, the Yue Tai Yu
+        vessels have operated near Chinese outposts in the Spratlys with no apparent
+        signs of fishing.
+      credit: CSIS
 contributors:
-- label: Research and Other Assistance
-  content: James DePoy, Mark Powell, and Jenna Thomas from Vulcan, Inc., and Conor
-    Cronin from CSIS.
-- label: Development and Design
-  content: This Spotlight is a product of the Andreas C. Dracopoulos iDeas Lab, the
-    in-house digital, multimedia, and design agency at the Center for Strategic and
-    International Studies.
-
+  - label: Research and Other Assistance
+    content:
+      James DePoy, Mark Powell, and Jenna Thomas from Vulcan, Inc., and Conor
+      Cronin from CSIS.
+  - label: Development and Design
+    content:
+      This Spotlight is a product of the Andreas C. Dracopoulos iDeas Lab, the
+      in-house digital, multimedia, and design agency at the Center for Strategic and
+      International Studies.
 ---
+
 The security implications of these disputes receive significant attention, and the disputants’ navies, air forces, and coast guards are studied closely to assess the balance of power and risk of escalation. But too little attention has focused on another key set of actors in the South China Sea—the fishers who serve on the frontlines of this contest. Those fishers face a dire threat to their livelihoods and food security as the South China Sea fisheries teeter on the brink of collapse.
 
 {% include sc-statistic.html align='right' number='50%' pre='More than' post='of the fishing vessels in the world are estimated to operate in the South China Sea.' %}
@@ -121,9 +129,8 @@ Coral reefs, on which much of these fish depend, have been declining by 16 perce
 
 {% include sc-image-group.html  height="65vh" images=page.image_groups.reefs width="max" %}
 
-
 {% include sc-single-image.html
-url="https://res.cloudinary.com/csisideaslab/image/upload/v1546651800/ocean/spratly-islands-location.jpg"
+url="https://res.cloudinary.com/csisideaslab/image/upload/v1546704680/ocean/spratly-islands-location.jpg"
 caption="The Spratly Islands are claimed in whole or in part by China, Taiwan, Vietnam, Brunei, Malaysia, and the Philippines."
 credit="CSIS"
 align="right"
@@ -140,7 +147,6 @@ The results tell a worrying story about the scale of unseen fishing activity in 
 
 Conducting accurate stock assessments and managing fisheries in the South China Sea is all but impossible because of the overlapping territorial and maritime disputes, which prevent effective enforcement of domestic fishery laws or cooperation among regional states. In fact, some states actively encourage and even subsidize fishing in disputed waters to assert their claims.
 
-
 {% include sc-tooltip-video.html
 name="How to read  AIS, VIIRS, and SAR data" url="https://player.vimeo.com/video/309369486" duration="2:09"
 thumbnail="https://res.cloudinary.com/csisideaslab/image/upload/v1546463269/ocean/poling-headshot.jpg"
@@ -150,6 +156,7 @@ align="right"
 Attempting to monitor fishing activity remotely is uniquely difficult in the South China Sea. Several different technologies are used to detect this activity–AIS, SAR, and VIIRS–and each tells a different story.
 
 ### Automatic Identification System (AIS)
+
 {% include sc-single-image.html
 url="https://res.cloudinary.com/csisideaslab/image/upload/v1546470965/ocean/june_ais_aggregate_lg%402x-80.jpg"
 mobile_url="https://res.cloudinary.com/csisideaslab/image/upload/v1546470965/ocean/june_ais_aggregate_sm%402x-80.jpg"
@@ -171,8 +178,8 @@ VIIRS data shows a significant amount of fishing in the South China Sea year-rou
     title="Monthly VIIRS detections in the South China Sea from 2013 to 2018"
     description="Visible Infrared Imaging Radiometer Suite (VIIRS) sensor reveals bright light sources at sea, providing insight into the overall level of night fishing activity in the South China Sea."
     start_date="Jan 2013"
-    end_date="Dec 2016"
-    image="https://res.cloudinary.com/csisideaslab/image/upload/v1546641648/ocean/VIIRS_gif.jpg"
+    end_date="May 2018"
+    image="https://res.cloudinary.com/csisideaslab/image/upload/f_auto,q_auto/v1546641648/ocean/VIIRS-2013-2018.jpg"
     steps=65
     component_width="medium"
     %}

--- a/assets/_js/lazy-load.js
+++ b/assets/_js/lazy-load.js
@@ -1,0 +1,3 @@
+import lazySizes from 'lazySizes'
+
+lazySizes.init()

--- a/assets/_js/spotlights/lightbox.js
+++ b/assets/_js/spotlights/lightbox.js
@@ -13,15 +13,21 @@ const Lightbox = () => {
     // prefixed classes will always be added as well.
     namespace: null,
     // Which attribute to pull the lightbox image source from.
-    sourceAttribute: 'src',
+    sourceAttribute: 'data-src',
     // Captions can be a literal string, or a function that receives the Luminous instance's trigger element as an argument and returns a string. Supports HTML, so use caution when dealing with user input.
     caption: e => {
-      if (e.parentNode.classList.contains('sc-single-image')) {
-        const caption = e.parentNode.querySelector('figcaption').innerHTML
+      let parentNode = e.parentNode
+
+      if (parentNode.classList.contains('sc-image-picture')) {
+        parentNode = e.parentNode.parentNode
+      }
+
+      if (parentNode.classList.contains('sc-single-image')) {
+        const caption = parentNode.querySelector('figcaption').innerHTML
 
         return `<div class="img-caption">${caption}</div>`
       } else if (
-        e.parentNode.classList.contains('sc-image-group__images-single')
+        parentNode.classList.contains('sc-image-group__images-single')
       ) {
         const component = e.closest('.sc-image-group')
 
@@ -37,7 +43,7 @@ const Lightbox = () => {
 
         return `<div class="img-caption">${caption}</div>`
       } else if (
-        e.parentNode.classList.contains('sc-image-gallery__image-single')
+        parentNode.classList.contains('sc-image-gallery__image-single')
       ) {
         const component = e.closest('.sc-image-gallery')
 

--- a/assets/_js/spotlights/scs/timeline.js
+++ b/assets/_js/spotlights/scs/timeline.js
@@ -13,9 +13,10 @@ const Timeline = () => {
       '.scs-timeline__scroll-container__graphic'
     )
 
-    const imageSrc = graphic.style.backgroundImage
-      .replace(/url\((['"])?(.*?)\1\)/gi, '$2')
-      .split(',')[0]
+    const imageSrc = graphic.style.backgroundImage.replace(
+      /url\((['"])?(.*?)\1\)/gi,
+      '$2'
+    )
 
     const image = new Image()
     image.src = imageSrc

--- a/assets/_sass/spotlights/components/_image-group.scss
+++ b/assets/_sass/spotlights/components/_image-group.scss
@@ -1,8 +1,14 @@
 .sc-image-group {
   img {
     width: 100%;
-    height: 100%;
-    object-fit: cover;
+    height: auto;
+    object-fit: contain;
+
+    @include breakpoint('medium') {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
   }
 
   &__images {
@@ -17,9 +23,12 @@
     &-single {
       position: relative;
       flex-basis: 100%;
-      height: 0;
-      padding-bottom: 56.25%;
-      overflow: hidden;
+
+      @include breakpoint('medium') {
+        height: 0;
+        padding-bottom: 56.25%;
+        overflow: hidden;
+      }
 
       &:not(:last-of-type) {
         margin-bottom: 0.5rem;
@@ -30,7 +39,9 @@
       }
 
       img {
-        position: absolute;
+        @include breakpoint('medium') {
+          position: absolute;
+        }
       }
     }
   }
@@ -43,11 +54,11 @@
     &-single {
       flex-basis: 100%;
 
-      @include breakpoint($break: 'medium', $dir: 'max-width') {
-        position: relative;
-        height: 0;
-        padding-bottom: 56.25%;
-      }
+      // @include breakpoint($break: 'medium', $dir: 'max-width') {
+      //   position: relative;
+      //   height: 0;
+      //   padding-bottom: 56.25%;
+      // }
 
       &:not(:last-of-type) {
         @include breakpoint($break: 'medium', $dir: 'max-width') {
@@ -68,9 +79,9 @@
       }
 
       img {
-        @include breakpoint($break: 'medium', $dir: 'max-width') {
-          position: absolute;
-        }
+        // @include breakpoint($break: 'medium', $dir: 'max-width') {
+        //   position: absolute;
+        // }
       }
     }
   }

--- a/frasco.config.js
+++ b/frasco.config.js
@@ -62,6 +62,7 @@ module.exports = {
       'spotlights.js',
       'archives.js',
       'home.js',
+      'lazy-load.js',
       'spotlights/arctic/arctic.js',
       'spotlights/scs/scs.js'
     ]
@@ -72,7 +73,7 @@ module.exports = {
     dest: 'css',
     outputStyle: 'compressed',
     autoprefixer: {
-      grid: "autoplace",
+      grid: 'autoplace',
       browsers: ['> 1%', 'last 2 versions', 'Firefox ESR']
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9347,6 +9347,11 @@
       "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
       "dev": true
     },
+    "lazysizes": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lazysizes/-/lazysizes-4.1.5.tgz",
+      "integrity": "sha512-ttO/1WiM7xQyyc9QWtmErltnsli21HYh59AqSQJKpjsUoykUG+vAZqp9zGr52/hHg2ICIBm8XyB0RHvATnOw9w=="
+    },
     "lazystream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "flickity": "^2.1.2",
     "gsap": "^2.0.2",
     "instantsearch.js": "^2.10.4",
+    "lazysizes": "^4.1.5",
     "luminous-lightbox": "^2.3.2",
     "pixi.js": "^4.8.4",
     "plyr": "^3.4.7",


### PR DESCRIPTION
Close #139 and #101 

This uses the [lazySizes](https://github.com/aFarkas/lazysizes) library to do lazy loading of inline images. Images are initially rendered using a low quality image placeholder to ensure limited shifting of the layout once the actual images are loaded. 

The `<picture>` tag is used in cases where a separate mobile image was specified to ensure that the correct image is displayed.

The Lightbox code was updated to account for the addition of the picture tag so that the caption will be pulled from the sibling figcaption. It was also updated to pull from the `data-src` attribute so it doesn't pull the LQIP instead of the full sized image. Note that even on mobile, the Lightbox will dispaly the desktop version of the image.

The styles on group and single images were also updated to not use `object-fit: cover;` on mobile to prevent the image from being cropped unnecessarily. Instead, the whole image will be displayed within the allowed proportions, even if it means having white space on either side of the image.