### PR TITLE
Fix/highcharts colors

### DIFF
--- a/assets/_js/spotlights/scs/chartCatch.js
+++ b/assets/_js/spotlights/scs/chartCatch.js
@@ -60,7 +60,7 @@ const chartCatch = () => {
         className: 'highcharts-series-spratly',
         color: {
           pattern: {
-            color: '#499ca2',
+            color: '#397D82',
             path: {
               d: 'M 0 0 L 3 3'
             },

--- a/assets/_js/spotlights/scs/chartCatch.js
+++ b/assets/_js/spotlights/scs/chartCatch.js
@@ -26,7 +26,7 @@ const chartCatch = () => {
       enabled: true,
       href: false,
       text:
-        'Developed based on information or analysis provided by Vulcan Technologies LLC.'
+        'Developed based on information or analysis provided by Vulcan Technologies LLC. | CSIS'
     },
     yAxis: {
       title: {

--- a/assets/_js/spotlights/scs/chartCatch.js
+++ b/assets/_js/spotlights/scs/chartCatch.js
@@ -54,7 +54,7 @@ const chartCatch = () => {
     series: [
       {
         className: 'highcharts-series-scs',
-        color: '#82c0de'
+        color: '#0663a1'
       },
       {
         className: 'highcharts-series-spratly',

--- a/assets/_js/spotlights/scs/chartCatch.js
+++ b/assets/_js/spotlights/scs/chartCatch.js
@@ -60,7 +60,7 @@ const chartCatch = () => {
         className: 'highcharts-series-spratly',
         color: {
           pattern: {
-            color: '#68c8d2',
+            color: '#499ca2',
             path: {
               d: 'M 0 0 L 3 3'
             },

--- a/assets/_js/spotlights/scs/chartCatch.js
+++ b/assets/_js/spotlights/scs/chartCatch.js
@@ -54,13 +54,13 @@ const chartCatch = () => {
     series: [
       {
         className: 'highcharts-series-scs',
-        color: '#0663a1'
+        color: '#68c8d2'
       },
       {
         className: 'highcharts-series-spratly',
         color: {
           pattern: {
-            color: '#0663a1',
+            color: '#68c8d2',
             path: {
               d: 'M 0 0 L 3 3'
             },

--- a/assets/_js/spotlights/scs/chartVessels.js
+++ b/assets/_js/spotlights/scs/chartVessels.js
@@ -90,7 +90,7 @@ const chartVessels = () => {
           borderWidth: 0,
           borderRadius: 3,
           className: 'highcharts-series-subi-column',
-          color: '#0663a1',
+          color: '#ef4723',
           events: {
             legendItemClick: function(e) {
               let match = this.chart.series.find(
@@ -107,7 +107,7 @@ const chartVessels = () => {
           borderWidth: 0,
           borderRadius: 3,
           className: 'highcharts-series-mischief-column',
-          color: '#ef4723',
+          color: '#0663a1',
           events: {
             legendItemClick: function(e) {
               let match = this.chart.series.find(
@@ -123,7 +123,7 @@ const chartVessels = () => {
           showInLegend: false,
           data: dataArray[0].data,
           className: 'highcharts-series-subi-area',
-          color: '#0663a1'
+          color: '#ef4723'
         },
         {
           type: 'area',
@@ -131,7 +131,7 @@ const chartVessels = () => {
           data: dataArray[1].data,
           showInLegend: false,
           className: 'highcharts-series-mischief-area',
-          color: '#ef4723'
+          color: '#0663a1'
         }
       ],
       responsive: {

--- a/assets/_js/spotlights/scs/chartVessels.js
+++ b/assets/_js/spotlights/scs/chartVessels.js
@@ -50,7 +50,7 @@ const chartVessels = () => {
         enabled: true,
         href: false,
         text:
-          'Developed based on information or analysis provided by Vulcan Technologies LLC.'
+          'Developed based on information or analysis provided by Vulcan Technologies LLC. | CSIS'
       },
       legend: {
         align: 'left',

--- a/assets/_js/spotlights/scs/chartVessels.js
+++ b/assets/_js/spotlights/scs/chartVessels.js
@@ -107,7 +107,7 @@ const chartVessels = () => {
           borderWidth: 0,
           borderRadius: 3,
           className: 'highcharts-series-mischief-column',
-          color: '#0663a1',
+          color: '#68c8d2',
           events: {
             legendItemClick: function(e) {
               let match = this.chart.series.find(
@@ -131,7 +131,7 @@ const chartVessels = () => {
           data: dataArray[1].data,
           showInLegend: false,
           className: 'highcharts-series-mischief-area',
-          color: '#0663a1'
+          color: '#68c8d2'
         }
       ],
       responsive: {

--- a/assets/_sass/abstracts/_variables.scss
+++ b/assets/_sass/abstracts/_variables.scss
@@ -23,6 +23,7 @@ $color__ltblue-dark: #2578a0;
 $color__ltblue-darker: #1c5a78;
 $color__red-lighter: #f6917b;
 $color__red-light: #f36c4f;
+$color__red-medlight: #eb9b8d;
 $color__red: #ef4723;
 $color__red-dark: #c0391c;
 $color__red-darker: #902b15;

--- a/assets/_sass/abstracts/_variables.scss
+++ b/assets/_sass/abstracts/_variables.scss
@@ -23,7 +23,6 @@ $color__ltblue-dark: #2578a0;
 $color__ltblue-darker: #1c5a78;
 $color__red-lighter: #f6917b;
 $color__red-light: #f36c4f;
-$color__red-medlight: #eb9b8d;
 $color__red: #ef4723;
 $color__red-dark: #c0391c;
 $color__red-darker: #902b15;

--- a/assets/_sass/spotlights/scs/_base.scss
+++ b/assets/_sass/spotlights/scs/_base.scss
@@ -4,6 +4,8 @@ $color__default-accent--hover: rgba($color__default-accent, 0.8);
 
 $color__map-bg: #131e24;
 
+$color__red-medlight: #eb9b8d;
+
 :root {
   --accent-color: #{$color__default-accent};
   --accent-color--hover: #{$color__default-accent--hover};

--- a/assets/_sass/spotlights/scs/_base.scss
+++ b/assets/_sass/spotlights/scs/_base.scss
@@ -5,7 +5,7 @@ $color__default-accent--hover: rgba($color__default-accent, 0.8);
 $color__map-bg: #131e24;
 
 $color__red-medlight: #eb9b8d;
-$color__default-accent-dkr: #499CA2;
+$color__default-accent-dkr: #397D82;
 
 :root {
   --accent-color: #{$color__default-accent};

--- a/assets/_sass/spotlights/scs/_base.scss
+++ b/assets/_sass/spotlights/scs/_base.scss
@@ -5,6 +5,7 @@ $color__default-accent--hover: rgba($color__default-accent, 0.8);
 $color__map-bg: #131e24;
 
 $color__red-medlight: #eb9b8d;
+$color__default-accent-dkr: #499CA2;
 
 :root {
   --accent-color: #{$color__default-accent};

--- a/assets/_sass/spotlights/scs/_charts.scss
+++ b/assets/_sass/spotlights/scs/_charts.scss
@@ -32,8 +32,8 @@
 
 #chartCatch {
   $china: $color__red;
-  $spratly: $color__medblue;
-  $scs: $color__medblue;
+  $spratly: $color__default-accent;
+  $scs: $color__default-accent;
 
   @extend %scs-chart;
 
@@ -43,8 +43,8 @@
 }
 
 #chartVessels {
-  $subi: $color__red;
-  $mischief: $color__medblue;
+  $subi: $color__red-medlight;
+  $mischief: $color__default-accent;
 
   @extend %scs-chart;
 

--- a/assets/_sass/spotlights/scs/_charts.scss
+++ b/assets/_sass/spotlights/scs/_charts.scss
@@ -32,7 +32,7 @@
 
 #chartCatch {
   $china: $color__red;
-  $spratly: $color__default-accent;
+  $spratly: $color__default-accent-dkr;
   $scs: $color__default-accent;
 
   @extend %scs-chart;

--- a/assets/_sass/spotlights/scs/_charts.scss
+++ b/assets/_sass/spotlights/scs/_charts.scss
@@ -33,7 +33,7 @@
 #chartCatch {
   $china: $color__red;
   $spratly: $color__medblue;
-  $scs: $color__ltblue-lighter;
+  $scs: $color__medblue;
 
   @extend %scs-chart;
 
@@ -43,8 +43,8 @@
 }
 
 #chartVessels {
-  $subi: $color__medblue;
-  $mischief: $color__red;
+  $subi: $color__red;
+  $mischief: $color__medblue;
 
   @extend %scs-chart;
 


### PR DESCRIPTION
Tucker has to approve the color changes, but these are essentially ready to go. 

Added the `$color__red-medlight: #eb9b8d;` variable to account for the red she gave. Not sure if I should have put that in the `base` file for the spotlight, as it's only used for that one chart.

![screen shot 2019-01-07 at 12 09 47 pm](https://user-images.githubusercontent.com/18509789/50782418-eab95980-1275-11e9-95fa-ec209de12caf.png)
![screen shot 2019-01-07 at 12 09 52 pm](https://user-images.githubusercontent.com/18509789/50782420-eb51f000-1275-11e9-8edb-699c9c8272f2.png)