### PR TITLE
more adjustments to home animation

### DIFF
--- a/_includes/home-top.html
+++ b/_includes/home-top.html
@@ -36,32 +36,6 @@
     <div id="water" data-per="0" data-wave="0"></div>
   </div>
   <div id="hero_bottom">
-    <div id="preserve-svg">
-      <svg viewBox="0 0 600 200">
-        <defs>
-          <filter id="turb">
-            <feTurbulence
-              id="turbwave"
-              type="fractalNoise"
-              baseFrequency="0.03"
-              numOctaves="2"
-              result="turbulence_3"
-              data-filterId="3"
-            />
-            <feDisplacementMap
-              id="diswave"
-              xChannelSelector="R"
-              yChannelSelector="G"
-              in="SourceGraphic"
-              in2="turbulence_3"
-              scale="40"
-            />
-          </filter>
-        </defs>
-        <!-- <text id="preserve" x="50%" y="50%">Preserve</text> -->
-      </svg>
-      <div id="preserve">Preserve</div>
-    </div>
 
     <div id="wave" data-per="0"></div>
     <div id="underwater-container">
@@ -71,9 +45,37 @@
         <div class="ray"></div>
         <div class="ray"></div>
       </div>
+      <div id="hero-bottom_intro">
+      <div id="preserve-svg">
+        <svg viewBox="0 0 600 200">
+          <defs>
+            <filter id="turb">
+              <feTurbulence
+                id="turbwave"
+                type="fractalNoise"
+                baseFrequency="0.03"
+                numOctaves="2"
+                result="turbulence_3"
+                data-filterId="3"
+              />
+              <feDisplacementMap
+                id="diswave"
+                xChannelSelector="R"
+                yChannelSelector="G"
+                in="SourceGraphic"
+                in2="turbulence_3"
+                scale="40"
+              />
+            </filter>
+          </defs>
+          <!-- <text id="preserve" x="50%" y="50%">Preserve</text> -->
+        </svg>
+        <div id="preserve">Preserve</div>
+      </div>
       <div id="intro-desc">
         <p>Explore the intersection of ocean conservation and national security.</p>
       </div>
+    </div>
     </div>
   </div>
 </section>

--- a/assets/_js/home.js
+++ b/assets/_js/home.js
@@ -32,7 +32,7 @@ function fpsMeasureLoop(timestamp) {
     timeDiff = timestamp - last
   }
 
-  if (timeDiff > 55) {
+  if (timeDiff > 50) {
     // change to 0 instead of 55 to see hero without pixi activated
     smoothRendering = false
   } else {
@@ -50,23 +50,16 @@ let webglSupported =
   !!canvas.getContext('webgl') || !!canvas.getContext('experimental-webgl')
 
 water_bg = document.querySelector('#water')
-// water_bg.style.backgroundImage = `url("/assets/images/home/water2.png"),url("/assets/images/home/water.png")`
-// water_bg.style.backgroundPositionY = `120%,0%`
-// water_bg.style.backgroundRepeat = `no-repeat`
 
 wave_front = document.querySelector('#wave')
-// wave_front.style.backgroundImage = `url(/assets/images/home/wave.png)`
-// wave_front.style.backgroundPositionY = `15%`
-// wave_front.style.backgroundRepeat = `no-repeat`
 
 setTimeout(() => {
   cancelAnimationFrame(req)
 
   if (smoothRendering && webglSupported) {
     InitWebGl()
-    // document.querySelector('#water').style.backgroundImage = `none`
-    // document.querySelector('#wave').style.backgroundImage = `none`
   } else {
+    document.querySelector('.ray-container').style.filter = 'none'
     document.querySelector('#preserve').style.filter = 'none'
     document.querySelector('#preserve-svg').classList.add('disable-animation')
 
@@ -85,7 +78,7 @@ setTimeout(() => {
 }, 500)
 
 function InitWebGl() {
-  if (Breakpoints.isMobile()) {
+  if (Breakpoints.isMobile() || Breakpoints.calculate() === 'xlarge-2') {
     return
   }
 
@@ -122,7 +115,7 @@ function InitWebGl() {
       container_water.removeChild(water_mesh)
     }
     water_mesh = new PIXI.mesh.Plane(this, 2, 4)
-    water_mesh.width = this.width //renderer.width * 0.35;
+    water_mesh.width = waterApp[0] //renderer.width * 0.35;
     water_mesh.height = this.height //renderer.width * 0.5;
     //console.log(this.height + " " + this.width);
     container_water.addChildAt(water_mesh, 0)
@@ -196,10 +189,19 @@ window.addEventListener('load', () => {
     tl = new TimelineMax()
   let waterID = document.getElementById('water').offsetHeight
   const waterY = waterID + 100
-  vTl
-    // .from(water_front, 5, { pixi: { alpha: 0, positionY: waterY }, delay: 4 }, 0)
-    .to('#clouds_1', 5, { y: '20' }, 0)
-    .to('#clouds_2', 5, { y: '15' }, '-=4')
+
+  if (water_front) {
+    vTl
+      .from(
+        water_front,
+        5,
+        { pixi: { alpha: 0, positionY: waterY }, delay: 4 },
+        0
+      )
+      .to('#clouds_1', 5, { y: '20' }, 0)
+      .to('#clouds_2', 5, { y: '15' }, '-=4')
+  }
+
   vT2.to('#turbwave', 4, { attr: { baseFrequency: 0.0 } }, 0)
 
   let ctrl = new ScrollMagic.Controller({
@@ -254,7 +256,8 @@ window.addEventListener('load', () => {
       document
         .getElementById('water')
         .setAttribute('data-per', e.progress.toFixed(3))
-      // water_bg.update()
+
+      if (water_bg.Texture) water_bg.update()
     })
     .on('leave', function(event) {
       if (event.scrollDirection == 'FORWARD') {

--- a/assets/_sass/base/_base.scss
+++ b/assets/_sass/base/_base.scss
@@ -38,8 +38,8 @@ body {
     --breakpoint: 'medium';
   }
 
-  @include breakpoint('large') {
-    --breakpoint: 'large';
+  @include breakpoint('xlarge-2') {
+    --breakpoint: 'xlarge-2';
   }
 }
 
@@ -63,7 +63,11 @@ body {
   &--home {
     @include structure($size__container-max-width, 'max-width');
     margin: 0 auto;
-    @include structure($size__container-padding--home, 'padding', ('small', 'large'));
+    @include structure(
+      $size__container-padding--home,
+      'padding',
+      ('small', 'large')
+    );
   }
 
   &--spotlight {

--- a/assets/_sass/components/_home-top.scss
+++ b/assets/_sass/components/_home-top.scss
@@ -23,7 +23,7 @@
     display: flex;
     flex-direction: column;
     width: 100vw;
-    height: 100vh;
+    height: 105vh;
     overflow: hidden;
     background: rgba(240, 242, 246, 1);
     background: radial-gradient(
@@ -51,6 +51,39 @@
     bottom: -100%;
     z-index: 15;
     width: 100vw;
+    height: 60vh;
+    min-height: 500px;
+    background: #0e2764;
+    background: linear-gradient(
+      75deg,
+      #0e2764 1%,
+      #1a4593 13%,
+      #447bb5 33%,
+      #447bb5 70%,
+      #1d509b 93%
+    );
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0e2764', endColorstr='#1d509b', GradientType=1);
+    animation: Gradient 5s ease infinite;
+
+    @include breakpoint('large') {
+      height: 800px;
+    }
+
+    &::after {
+      position: absolute;
+      top: 0;
+      display: block;
+      width: 100vw;
+      height: 101%;
+      background: rgb(10, 63, 131);
+      background: linear-gradient(
+        0deg,
+        rgba(10, 63, 131, 1) 0%,
+        rgba(10, 63, 131, 0) 100%
+      );
+      filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0a3f83', endColorstr='#0a3f83', GradientType=1);
+      content: '';
+    }
   }
 
   #sky {
@@ -120,7 +153,7 @@
     left: 0;
     z-index: 5;
     width: 100vw;
-    height: 100vh;
+    height: 55vh;
     margin-top: -20vh;
     overflow: hidden;
     background: url('#{$img__home}wave.png');
@@ -171,31 +204,43 @@
     }
   }
 
+  #protect {
+    display: inline-flex;
+  }
+
   #preserve-svg {
-    position: absolute;
-    top: -60%;
+    position: relative;
+    top: -200px;
     letter-spacing: 0.25rem;
     opacity: 0;
     transition: opacity 0.5s, top 1s;
 
     &:not(.disable-animation) {
-      top: -20%;
+      top: -200px;
       opacity: 0;
       transition: opacity 0.5s, top 1s;
     }
 
     &.pactive {
-      position: absolute;
-      top: 20%;
+      position: relative;
+      top: 0;
       opacity: 1;
       transition: opacity 3s, top 1s;
     }
   }
 
+  #hero-bottom_intro {
+    position: absolute;
+    top: 60%;
+    display: block;
+    z-index: 1;
+    width: 100%;
+    transform: translateY(-50%);
+  }
+
   #protect-svg {
     position: fixed;
     top: 33%;
-    letter-spacing: -0.75rem;
     opacity: 1;
     transition: opacity 2s, top 2s;
 
@@ -262,35 +307,8 @@
   }
 
   #underwater-container {
-    height: 80vh;
-    min-height: 800px;
-    background: #0e2764;
-    background: linear-gradient(
-      75deg,
-      #0e2764 1%,
-      #1a4593 13%,
-      #447bb5 33%,
-      #447bb5 70%,
-      #1d509b 93%
-    );
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0e2764', endColorstr='#1d509b', GradientType=1);
-    animation: Gradient 5s ease infinite;
-
-    &::after {
-      position: absolute;
-      top: 0;
-      display: block;
-      width: 100vw;
-      height: 101%;
-      background: rgb(10, 63, 131);
-      background: linear-gradient(
-        0deg,
-        rgba(10, 63, 131, 1) 0%,
-        rgba(10, 63, 131, 0) 100%
-      );
-      filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0a3f83', endColorstr='#0a3f83', GradientType=1);
-      content: '';
-    }
+    position: relative;
+    height: 100%;
   }
 
   .ray-container {
@@ -422,8 +440,7 @@
   }
 
   #intro-desc {
-    position: absolute;
-    bottom: 25%;
+    position: relative;
     z-index: 1;
     display: block;
     width: 100%;
@@ -432,7 +449,7 @@
       max-width: 800px;
       margin: 0 auto;
       padding: 0 20px;
-      color: $color__white;
+      color: $color__ltgray-light;
       font-family: $font__freight;
       @include font-size(30px);
       font-style: italic;

--- a/assets/_sass/components/_home-top.scss
+++ b/assets/_sass/components/_home-top.scss
@@ -19,7 +19,6 @@
   }
 
   #hero_top {
-    // position: relative !important;
     z-index: 2;
     display: flex;
     flex-direction: column;
@@ -34,7 +33,7 @@
       rgba(158, 179, 208, 1) 100%
     );
 
-    //filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f2f6', endColorstr='#9eb3d0', GradientType=1);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f2f6', endColorstr='#9eb3d0', GradientType=1);
 
     .hero-logo {
       display: block;
@@ -106,9 +105,10 @@
         display: block;
         width: 1500px;
         height: 100%;
-        background: url('#{$img__home}water2.png'), url('#{$img__home}water.png');
-        background-repeat: no-repeat;
-        background-position-y: 120%,0;
+        background: url('#{$img__home}water2.png'),
+          url('#{$img__home}water.png');
+        background-repeat: repeat-x;
+        background-position-y: 120%, 0;
         transform: scaleX(-1);
       }
     }
@@ -138,7 +138,7 @@
         width: 1500px;
         height: 100%;
         background: url('#{$img__home}wave.png');
-        background-repeat: no-repeat;
+        background-repeat: repeat-x;
         background-position-y: 15%;
         transform: scaleX(-1);
         transition: left 1s ease-in-out;
@@ -253,7 +253,7 @@
 
   #protect-svg span {
     display: inline-block;
-    // text-shadow: 0 0 0 $color__white;
+    text-shadow: 0 0 0 $color__white;
     transform: matrix(0.9, 0.3, 0, 0.4, -100, -100);
     transform-origin: 0 0;
     opacity: 0;
@@ -274,8 +274,7 @@
       #1d509b 93%
     );
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0e2764', endColorstr='#1d509b', GradientType=1);
-    // filter: blur(6px);
-    // animation: Gradient 5s ease infinite;
+    animation: Gradient 5s ease infinite;
 
     &::after {
       position: absolute;
@@ -301,6 +300,7 @@
     height: 70%;
     margin-top: 10vh;
     overflow: hidden;
+    filter: blur(6px);
   }
 
   .ray {
@@ -319,8 +319,16 @@
     transform: scale(1) rotate(0) translateX(0) translateY(0) skewX(30deg)
       skewY(0deg);
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00ffffff', endColorstr='#00ffffff', GradientType=0);
-    // filter: blur(6px);
     transition: all 1000ms ease;
+
+    &:not(.disable-animation) {
+      filter: blur(6px);
+
+      &::before,
+      &::after {
+        filter: blur(10px);
+      }
+    }
   }
 
   .ray::before,
@@ -338,7 +346,6 @@
       rgba(255, 255, 255, 0) 100%
     );
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00ffffff', endColorstr='#00ffffff', GradientType=0); /* IE6-9 */
-    // filter: blur(10px);
     content: '';
   }
 

--- a/assets/_sass/components/_home-top.scss
+++ b/assets/_sass/components/_home-top.scss
@@ -240,8 +240,8 @@
   #hero-bottom_intro {
     position: absolute;
     top: 60%;
-    display: block;
     z-index: 1;
+    display: block;
     width: 100%;
     transform: translateY(-50%);
   }

--- a/assets/_sass/components/_home-top.scss
+++ b/assets/_sass/components/_home-top.scss
@@ -107,7 +107,7 @@
         height: 100%;
         background: url('#{$img__home}water2.png'),
           url('#{$img__home}water.png');
-        background-repeat: repeat-x;
+        background-repeat: no-repeat;
         background-position-y: 120%, 0;
         transform: scaleX(-1);
       }
@@ -138,7 +138,7 @@
         width: 1500px;
         height: 100%;
         background: url('#{$img__home}wave.png');
-        background-repeat: repeat-x;
+        background-repeat: no-repeat;
         background-position-y: 15%;
         transform: scaleX(-1);
         transition: left 1s ease-in-out;


### PR DESCRIPTION
I tested this by disabling webgl in firefox (//about:config) and disabling hardware acceleration under chrome advanced system settings

summary of changes:
- Since the background images are added at the xlarge-2 breakpoint in _home-top.scss I added a css variable for that breakpoint I adjusted the js to not load pixi at that breakpoint (home.js line #81)
- Even with hardware acceleration, the filters and blurs look fine on this screen where they performed poorly on my laptop at home. I put the filters on the rays back in under the same :not(.disable-animation) condition that the animations on the rays already have.
- Lastly, I think I figured out why the canvas element wasn't taking up the whole screen width, so I adjusted each canvas width to be the same App width.

The scrollTo and TweenMax.to were a real problem on my home plaptop, but I wasn't able to replicate the issue here. I commented those sections out when I looked at it in December. I could checkout how things are working on my laptop later today. [reference](https://github.com/CSIS-iLab/ocean/commit/62b079ec1b5b613442a35d4a67c9b056b221ad05#diff-2ffc582b925f7e12a337bdeb9704cc40R227)