### PR TITLE
Rework logic for footer height calculations on mobile

### DIFF
--- a/_includes/sc-footer.html
+++ b/_includes/sc-footer.html
@@ -1,4 +1,4 @@
-<footer class="spotlight__footer js-footer-bg">
+<footer class="spotlight__footer">
   <section class="spotlight__footer-top">
     {%- if page.methodology -%}
     <section id="methodology">
@@ -44,7 +44,7 @@
 
   </section>
 
-  <section class="spotlight__footer-middle">
+  <section class="spotlight__footer-middle js-footer-bg">
       <div class="keywords">{% include keywords.html %}</div>
       {%- include social-share.html class="post__footer"  -%}
   </section>

--- a/assets/_js/footer-bg-height.js
+++ b/assets/_js/footer-bg-height.js
@@ -8,6 +8,10 @@ const CalcHeight = el => {
   let height =
     document.documentElement.scrollHeight - el.offsetTop - el.offsetHeight
 
+  if (Breakpoints.isMobile() || Breakpoints.calculate() === 'medium') {
+    height -= document.querySelector('.site-footer').offsetHeight
+  }
+
   // On single posts page, calculate from top of element instead of bottom.
   if (el.classList.contains('js-footer-bg-switch') && !Breakpoints.isMobile()) {
     height = height + el.offsetHeight
@@ -21,6 +25,7 @@ const CalcHeight = el => {
 
 const FooterBgHeight = () => {
   const el = document.querySelector('.js-footer-bg')
+  let breakpoint = Breakpoints.calculate()
 
   if (!el) {
     return
@@ -29,7 +34,13 @@ const FooterBgHeight = () => {
   CalcHeight(el)
 
   window.addEventListener('resize', () => {
-    CalcHeight(el)
+    let newBreakpoint = Breakpoints.calculate()
+    if (breakpoint !== newBreakpoint) {
+      breakpoint = newBreakpoint
+      CalcHeight(el)
+    } else if (newBreakpoint == 'large') {
+      CalcHeight(el)
+    }
   })
 }
 

--- a/assets/_sass/base/_base.scss
+++ b/assets/_sass/base/_base.scss
@@ -38,6 +38,14 @@ body {
     --breakpoint: 'medium';
   }
 
+  @include breakpoint('large') {
+    --breakpoint: 'large';
+  }
+
+  @include breakpoint('xlarge') {
+    --breakpoint: 'xlarge';
+  }
+
   @include breakpoint('xlarge-2') {
     --breakpoint: 'xlarge-2';
   }

--- a/assets/_sass/layout/_footer.scss
+++ b/assets/_sass/layout/_footer.scss
@@ -1,31 +1,51 @@
 .site-footer {
+  position: relative;
   @include structure($size__container-max-width, 'max-width');
   margin-right: auto;
   margin-left: auto;
   @include structure($size__footer-padding-top, 'padding-top');
 
+  @include breakpoint('large') {
+    position: static;
+  }
+
   &::before {
+    $footer-padding-bottom: map-get($size__footer-padding-top, 'small');
     content: '';
     position: absolute;
     right: 0;
-    bottom: 0;
+    bottom: calc(100% - #{$footer-padding-bottom});
     left: 0;
     z-index: -1;
     display: block;
     width: 100vw;
-    height: var(--footer-bg-min-height);
-    max-height: 1000px;
+    height: calc(var(--footer-bg-min-height) + #{$footer-padding-bottom});
+    max-height: 600px;
     background-color: $color__dkblue-darker;
     @include bg-footer;
     background-repeat: no-repeat;
+    background-position: center top;
     background-size: cover;
 
+    @include breakpoint('medium') {
+      $footer-padding-bottom: map-get($size__footer-padding-top, 'medium');
+      bottom: calc(100% - #{$footer-padding-bottom});
+      height: calc(
+        var(--footer-bg-min-height) + #{$footer-padding-bottom}
+      );
+    }
+
     @include breakpoint('large') {
+      bottom: 0;
+      height: var(--footer-bg-min-height);
       max-height: 800px;
     }
 
     .layout-archive & {
-      height: calc(var(--footer-bg-min-height) + 100px);
+      @include breakpoint($break: 'medium', $dir: 'max-width') {
+        $footer-padding-bottom: map-get($size__footer-padding-top, 'small');
+        height: calc(var(--footer-bg-min-height) + #{$footer-padding-bottom} + 100px);
+      }
     }
   }
 

--- a/assets/_sass/pages/_archive.scss
+++ b/assets/_sass/pages/_archive.scss
@@ -164,10 +164,11 @@
     &::after {
       @extend %content-side-gradient;
       top: calc(var(--archive-cutout-height) - 2rem);
-      bottom: -2.5rem;
+      bottom: -3.5rem;
       display: block;
 
       @include breakpoint('large') {
+        // prettier-ignore
         $width_offset: nth(
           map-get(
             $map: $size__content-margin--archive,
@@ -179,6 +180,7 @@
       }
 
       @include breakpoint('xlarge') {
+        // prettier-ignore
         $width_offset: nth(
           map-get(
             $map: $size__content-margin--archive,
@@ -190,7 +192,7 @@
       }
 
       #{$a}--spotlights & {
-        bottom: 0;
+        bottom: -1.5rem;
       }
 
       #{$a}--search & {


### PR DESCRIPTION
Close #43 

Adjusts the height of the footer image on mobile by making it relative to the footer instead of the entire page. This helps to reduce the graininess of the image. Also adjusted padding & margins to smooth out the gradient as it fades into the footer.