### PR TITLE
Fix/arctic

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -7,6 +7,12 @@
     "function-parentheses-space-inside": "never-single-line",
     "selector-class-pattern": "^(?:(?:o|c|u|t|s|is|has|_|js|qa)-)?[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*(?:__[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:--[a-zA-Z0-9]+(?:[a-zA-Z0-9-_]+)*)?(?:\\[.+\\])?$",
     "selector-max-id": 1,
+    "selector-no-qualifying-type": [
+      true,
+      {
+        "ignore": ["attribute"]
+      }
+    ],
     "max-nesting-depth": [
       3,
       {

--- a/_spotlights/arctic/map-scrollytelling.html
+++ b/_spotlights/arctic/map-scrollytelling.html
@@ -43,6 +43,7 @@
         </ul>
       </div>
       {% include_relative arctic/map-svg.html %}
+      <div class="arctic__map-source">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. | CSIS</div>
     </div>
   </div>
   <div class="arctic__map-prose">

--- a/_spotlights/arctic/map-scrollytelling.html
+++ b/_spotlights/arctic/map-scrollytelling.html
@@ -43,7 +43,9 @@
         </ul>
       </div>
       {% include_relative arctic/map-svg.html %}
-      <div class="arctic__map-source">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. | CSIS</div>
+      <div class="arctic__map-source">
+        CSIS | Data from National Snow and Ice Data Center
+      </div>
     </div>
   </div>
   <div class="arctic__map-prose">
@@ -63,19 +65,34 @@
       <p>For nearly 40 years, scientists have monitored this ebb and flow.</p>
       <p>
         In 2018, Arctic sea ice extent reached its
-        <a href="https://nsidc.org/arcticseaicenews/2018/03/arctic-sea-ice-maximum-second-lowest/" target="_blank" rel="noopener">maximum at 5.59 million square miles</a>, which is the second lowest ever recorded confirming that the Arctic
+        <a
+          href="https://nsidc.org/arcticseaicenews/2018/03/arctic-sea-ice-maximum-second-lowest/"
+          target="_blank"
+          rel="noopener"
+          >maximum at 5.59 million square miles</a
+        >, which is the second lowest ever recorded confirming that the Arctic
         continues to melt on an annual basis and at a record pace.
       </p>
     </div>
     <p class="arctic__map-trigger" data-step="3">
       The
-      <a href="https://nsidc.org/arcticseaicenews/2018/03/arctic-sea-ice-maximum-second-lowest/" target="_blank" rel="noopener">four lowest seasonal maxima</a>
+      <a
+        href="https://nsidc.org/arcticseaicenews/2018/03/arctic-sea-ice-maximum-second-lowest/"
+        target="_blank"
+        rel="noopener"
+        >four lowest seasonal maxima</a
+      >
       have all occurred during the last four years.
     </p>
     <p class="arctic__map-trigger" data-step="4">
       Record findings are also being reported for summer sea ice extent. This
       past September, sea ice extent reached an
-      <a href="https://nsidc.org/arcticseaicenews/2017/09/arctic-sea-ice-at-minimum-extent-2/" target="_blank" rel="noopener">annual minimum of 1.77 million square miles</a>, 629,000 square miles below the 1981 to 2010 median extent. It is the
+      <a
+        href="https://nsidc.org/arcticseaicenews/2017/09/arctic-sea-ice-at-minimum-extent-2/"
+        target="_blank"
+        rel="noopener"
+        >annual minimum of 1.77 million square miles</a
+      >, 629,000 square miles below the 1981 to 2010 median extent. It is the
       sixth lowest retreat since monitoring began.
     </p>
   </div>

--- a/_spotlights/charting-a-new-arctic-ocean.md
+++ b/_spotlights/charting-a-new-arctic-ocean.md
@@ -36,10 +36,6 @@ related_spotlight:
 related_commentary:
   - _posts/2018-12-10-making-the-oceans-more-secure.md
 contributors:
-  - label: illustration
-    content:
-      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
-      ut aliquip ex ea commodo consequat.
   - label: development and design
     content:
       This Spotlight is a product of the Andreas C. Dracopoulos iDeas Lab, the

--- a/assets/_js/spotlights/footnotes.js
+++ b/assets/_js/spotlights/footnotes.js
@@ -9,7 +9,7 @@ const Footnotes = () => {
   footnotes.parentNode.insertBefore(readMore, footnotes.nextSibling)
 
   const hiddenFootnotes = document.querySelectorAll(
-    '.footnotes ol li:nth-child(5) ~ li'
+    '.footnotes ol li:nth-child(3) ~ li'
   )
 
   const toggle = ariaExpanded => {

--- a/assets/_sass/spotlights/arctic/_base.scss
+++ b/assets/_sass/spotlights/arctic/_base.scss
@@ -6,6 +6,8 @@ $color__map-bg: #647899;
 $color__map-ice-base: #b6c2d1;
 $color__map-median: #d8ab52;
 
+$hidden-years: (2015, 2016, 2017);
+
 $color__map-ice: (
   2018: $color__map-ice-base,
   2017: #a39ebf,

--- a/assets/_sass/spotlights/arctic/_scrollytelling-map.scss
+++ b/assets/_sass/spotlights/arctic/_scrollytelling-map.scss
@@ -179,10 +179,22 @@
     }
 
     &:not(:disabled) {
+      /* stylelint-enable */
+      padding-right: 1.5rem;
+      color: $color__black;
       font-weight: 400;
+      background-image: linear-gradient(
+        45deg,
+        transparent 50%,
+        $color__white 50%
+      ),
+        linear-gradient(135deg, $color__white 50%, transparent 50%);
+      background-repeat: no-repeat;
+      background-position: calc(100% - 20px) 50%, calc(100% - 15px) 50%;
+      background-size: 5px 5px, 5px 5px;
       /* stylelint-disable */
-      -webkit-appearance: menulist-button;
-      -moz-appearance: menulist-button;
+      -webkit-appearance: none;
+      -moz-appearance: none;
     }
   }
 
@@ -205,16 +217,16 @@
     margin-bottom: 0 !important;
 
     &.arctic__legend-key--median {
-      grid-column: span 2;
       display: none;
+      grid-column: span 2;
 
       &::before {
-        content: '';
         display: inline-block;
         width: 2rem;
         height: 3px;
         margin-right: 1rem;
         background-color: $color__map-median;
+        content: '';
       }
     }
 
@@ -254,12 +266,12 @@
   }
 
   input[type='checkbox'] + label::before {
-    content: '';
-    align-self: stretch;
     display: inline-block;
+    align-self: stretch;
     width: 2rem;
     margin-right: 0.5rem;
     transition: 0.2s;
+    content: '';
   }
 
   @each $year, $color in $color__map-ice {

--- a/assets/_sass/spotlights/arctic/_scrollytelling-map.scss
+++ b/assets/_sass/spotlights/arctic/_scrollytelling-map.scss
@@ -179,22 +179,14 @@
     }
 
     &:not(:disabled) {
-      /* stylelint-enable */
-      padding-right: 1.5rem;
-      color: $color__black;
-      font-weight: 400;
-      background-image: linear-gradient(
-        45deg,
-        transparent 50%,
-        $color__white 50%
-      ),
-        linear-gradient(135deg, $color__white 50%, transparent 50%);
-      background-repeat: no-repeat;
-      background-position: calc(100% - 20px) 50%, calc(100% - 15px) 50%;
-      background-size: 5px 5px, 5px 5px;
       /* stylelint-disable */
-      -webkit-appearance: none;
-      -moz-appearance: none;
+      -webkit-appearance: menulist-button;
+      -moz-appearance: menulist-button;
+      /* stylelint-enable */
+
+      option {
+        color: $color__black;
+      }
     }
   }
 

--- a/assets/_sass/spotlights/arctic/_scrollytelling-map.scss
+++ b/assets/_sass/spotlights/arctic/_scrollytelling-map.scss
@@ -222,7 +222,6 @@
       }
     }
 
-    $hidden-years: (2015, 2016, 2017);
     @each $year in $hidden-years {
       &.ice--#{$year} {
         display: none;

--- a/assets/_sass/spotlights/arctic/_scrollytelling-map.scss
+++ b/assets/_sass/spotlights/arctic/_scrollytelling-map.scss
@@ -231,6 +231,14 @@
   }
 }
 
+#{$spotlight}__map-source {
+  position: relative;
+  top: -64px;
+  padding: 1rem 1rem 0;
+  @extend %post-content__caption-desc--sm;
+  color: $color__white;
+  line-height: 1.33;
+}
 // Checkbox
 .checkbox-container {
   position: relative;


### PR DESCRIPTION
Completed items at end of #226 

I noticed that the arrow is black in Edge 🤷‍♀️ 
Source credit style is based on the credit below scs-timeline

- [x] On the scrollytelling dropdown, the `<option>` text should be black (but the selector text should stay white)
- [x] Remove the illustration credit
- [x] Adjust the footnotes so only the first 3 show
- [x] Add text to the bottom of the scrollytelling container for source credit. Use placeholder text for now.