### PR TITLE
Bug/design fixes

### DIFF
--- a/assets/_sass/abstracts/_placeholders.scss
+++ b/assets/_sass/abstracts/_placeholders.scss
@@ -58,7 +58,7 @@
     content: '';
     position: absolute;
     top: calc(var(--archive-cutout-height) - 2rem);
-    bottom: -3.5rem;
+    bottom: -9rem;
     left: 100%;
     width: calc((100vw - 100%) / 2 - 1px);
     // prettier-ignore
@@ -68,7 +68,7 @@
       rgba(14, 26, 44, 0),
       rgba(14, 26, 44, 0.8) 80px,
       #081324 120px,
-      #081324 89%,
+      #081324 92.7%,
       rgba(0, 11, 14, 0.01)
     );
   }

--- a/assets/_sass/base/_typography.scss
+++ b/assets/_sass/base/_typography.scss
@@ -41,25 +41,22 @@ p {
       p + h#{$i} {
         margin-top: 4rem;
       }
-
-      ul + h#{$i},
-      ol + h#{$i},
-      section + h#{$i} {
-        margin-top: 3rem;
-      }
     }
   } @else {
     .post-content {
-      p + h#{$i},
-      ul + h#{$i},
-      ol + h#{$i},
-      section + h#{$i} {
+      p + h#{$i} {
         margin-top: 3rem;
       }
     }
   }
 
   .post-content {
+    ul + h#{$i},
+    ol + h#{$i},
+    section + h#{$i} {
+      margin-top: 3rem;
+    }
+
     h#{$i} {
       @extend %#{$placeholder} !optional;
       margin-bottom: 1rem;

--- a/assets/_sass/base/_typography.scss
+++ b/assets/_sass/base/_typography.scss
@@ -24,7 +24,7 @@ textarea {
 ============================*/
 
 .post-content,
-.post-content p {
+.post-content > p {
   @extend %post-content__body;
 }
 
@@ -41,7 +41,7 @@ p {
       p + h#{$i} {
         margin-top: 4rem;
       }
-      
+
       ul + h#{$i},
       ol + h#{$i},
       section + h#{$i} {

--- a/assets/_sass/base/_typography.scss
+++ b/assets/_sass/base/_typography.scss
@@ -36,21 +36,33 @@ p {
 @for $i from 2 through 6 {
   $placeholder: post-content__h#{$i};
 
-  .post-content {
-    p + h#{$i},
-    ul + h#{$i},
-    ol + h#{$i},
-    section + h#{$i} {
-      margin-top: 3rem;
+  @if $i == 2 {
+    .post-content {
+      p + h#{$i} {
+        margin-top: 4rem;
+      }
+      
+      ul + h#{$i},
+      ol + h#{$i},
+      section + h#{$i} {
+        margin-top: 3rem;
+      }
     }
+  } @else {
+    .post-content {
+      p + h#{$i},
+      ul + h#{$i},
+      ol + h#{$i},
+      section + h#{$i} {
+        margin-top: 3rem;
+      }
+    }
+  }
 
+  .post-content {
     h#{$i} {
       @extend %#{$placeholder} !optional;
-      @if $i == 2 {
-        margin-bottom: 2rem;
-      } @else {
-        margin-bottom: 1rem;
-      }
+      margin-bottom: 1rem;
     }
   }
 }

--- a/assets/_sass/components/_footnotes.scss
+++ b/assets/_sass/components/_footnotes.scss
@@ -11,6 +11,10 @@
     text-transform: uppercase;
   }
 
+  ol {
+    margin-top: 0.25rem;
+  }
+
   li,
   p {
     @extend %body-text__med;

--- a/assets/_sass/components/_media.scss
+++ b/assets/_sass/components/_media.scss
@@ -40,8 +40,7 @@ iframe {
 }
 
 figure {
-  margin: 0;
-  margin-bottom: 1rem;
+  margin: 2rem 0;
 
   img {
     display: block;

--- a/assets/_sass/layout/_footer.scss
+++ b/assets/_sass/layout/_footer.scss
@@ -308,11 +308,11 @@
   }
 
   &__email::before {
-    content: '\e811';
+    content: '\e81b';
     @include font-size(11px);
     top: 2px;
   }
-  
+
   &__twitter::before {
     content: '\e82f';
     @include font-size(11px);

--- a/assets/_sass/pages/_archive.scss
+++ b/assets/_sass/pages/_archive.scss
@@ -106,7 +106,6 @@
       position: relative;
       box-sizing: content-box;
       @include structure($size__content-margin--post, 'margin');
-      overflow: hidden;
 
       @each $size in ('medium', 'large', 'xlarge') {
         @include breakpoint($size) {

--- a/assets/_sass/pages/_post.scss
+++ b/assets/_sass/pages/_post.scss
@@ -182,7 +182,7 @@
     padding-bottom: 0.5rem;
 
     @include breakpoint('medium') {
-      margin-bottom: 2rem;
+      margin-bottom: 1rem;
       padding-top: 2rem;
       background-color: $color__white;
       border-left: 1px solid $color__gray-58;

--- a/assets/_sass/pages/_post.scss
+++ b/assets/_sass/pages/_post.scss
@@ -201,7 +201,7 @@
         left: 100%;
         width: calc((100vw - 100%) / 2 - 1px);
         // prettier-ignore
-        background-image: linear-gradient(180deg, rgba(14, 26, 44, 0), rgba(14, 26, 44, 0.8) 80px, #081324 120px, #081324 95%, rgba(0, 11, 14, 0.01));
+        background-image: linear-gradient(180deg, rgba(14, 26, 44, 0), rgba(14, 26, 44, 0.8) 80px, #081324 120px, #081324 97.7%, rgba(0, 11, 14, 0.01));
       }
 
       @include breakpoint('large') {

--- a/assets/_sass/pages/_post.scss
+++ b/assets/_sass/pages/_post.scss
@@ -115,6 +115,7 @@
 
     #{$post}-title {
       @extend %post-title;
+      max-width: 700px;
       margin: 0.75rem 0;
     }
 
@@ -182,7 +183,7 @@
     padding-bottom: 0.5rem;
 
     @include breakpoint('medium') {
-      margin-bottom: 1rem;
+      margin-bottom: 2rem;
       padding-top: 2rem;
       background-color: $color__white;
       border-left: 1px solid $color__gray-58;
@@ -229,6 +230,7 @@
 
   &-lede {
     order: 2;
+    max-width: 700px;
     margin: 0 0 1rem;
     @extend %post-lede;
 


### PR DESCRIPTION
closes #247 

Commentary & Archive Pages
 There is a gap between the end of the gradient and the beginning on the footer image on commentary and archive pages.
Note: The issue is being caused by the percentages in the gradient, not the footer image. It should be updated to the below. On the archive pages, you can also adjust the value of the bottom property on .archive__content::after
background-image: linear-gradient(180deg,rgba(14,26,44,0),rgba(14,26,44,.8) 80px,#081324 120px,#081324 97.7%,rgba(0,11,14,.01));
Archive Pages
 On the archive pages, the gray line on the side should be extended all the way to the post content. This can be done by removing the overflow: hidden; from the .archive__desc class


Commentary Pages
 Let's give media a tad more spacing:figure {margin: 2rem 0; }
 For headings: add a bit more space to margin on top, and little less below:
.post-content p+h2 {    
    margin-top: 4rem;
}
.post-content h2 {
    margin-bottom: 1rem;
}
 reduce margin after "NOTES" heading: .footnotes ol {margin-top: 0.25rem;}

 Footnotes should be the regular body text, not post-content paragraph text. To fix this, line 27 in _typography.scss to .post-content > p, so only direct child paragraphs are impacted.

 Give .post-lede and .post-title a max-width of 700px

Footer
 Mail icon is using the incorrect icon. It should be \e81b.
image